### PR TITLE
navigation.ymlに第0部入門編セクションを追加

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -3,6 +3,14 @@ introduction:
   - title: "はじめに"
     path: "/introduction/"
 
+part0_intro:
+  - title: "第0章：コンテナ技術基礎"
+    path: "/chapters/chapter00/"
+  - title: "第1章：Podman概要と環境構築"
+    path: "/chapters/chapter01-intro/"
+  - title: "第2章：基本操作と内部理解"
+    path: "/chapters/chapter02-intro/"
+
 chapters:
   - title: "第1章：コンテナ技術の基礎"
     path: "/chapters/chapter01/"


### PR DESCRIPTION
## 概要
第0部入門編がWebサイトに表示されない根本的な原因を修正。navigation.ymlにpart0_introセクションが欠けていました。

## 問題
- PR #13でPart 0のコンテンツ（第0-2章）は作成済み
- PR #14でsidebar-nav.htmlテンプレートも修正済み  
- しかしnavigation.ymlにpart0_introセクションが定義されていない

## 修正内容
navigation.ymlに以下のpart0_introセクションを追加:
- 第0章：コンテナ技術基礎 (/chapters/chapter00/)
- 第1章：Podman概要と環境構築 (/chapters/chapter01-intro/)
- 第2章：基本操作と内部理解 (/chapters/chapter02-intro/)

🤖 Generated with [Claude Code](https://claude.ai/code)