### PR TITLE
ビルドスクリプトとテンプレートを修正して第0部入門編を表示

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -37,6 +37,40 @@
     </div>
     {% endif %}
 
+    <!-- Part 0: Introduction Guide -->
+    {% if site.data.navigation.part0_intro %}
+    <div class="nav-section">
+        <h3 class="nav-section-title">第0部：入門編</h3>
+        <ul class="nav-list">
+            {% for chapter in site.data.navigation.part0_intro %}
+            <li class="nav-item">
+                <a href="{{ site.baseurl }}{{ chapter.path }}" 
+                   class="nav-link{% if page.url contains chapter.path %} active{% endif %}"
+                   aria-current="{% if page.url contains chapter.path %}page{% endif %}">
+                    <span class="nav-number">{{ forloop.index0 }}</span>
+                    <span class="nav-title">{{ chapter.title }}</span>
+                </a>
+                
+                <!-- Sub-sections if available -->
+                {% if chapter.sections %}
+                <ul class="nav-subsections">
+                    {% for section in chapter.sections %}
+                    <li class="nav-subsection">
+                        <a href="{{ site.baseurl }}{{ section.path }}" 
+                           class="nav-sublink{% if page.url == section.path %} active{% endif %}"
+                           aria-current="{% if page.url == section.path %}page{% endif %}">
+                            {{ section.title }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
     <!-- Chapters -->
     {% if site.data.navigation.chapters %}
     <div class="nav-section">
@@ -123,12 +157,15 @@
 
 <!-- Progress Indicator -->
 {% assign total_pages = site.data.navigation.chapters.size %}
+{% if site.data.navigation.part0_intro %}
+{% assign total_pages = total_pages | plus: site.data.navigation.part0_intro.size %}
+{% endif %}
 {% if site.data.navigation.appendices %}
 {% assign total_pages = total_pages | plus: site.data.navigation.appendices.size %}
 {% endif %}
 
 {% assign current_index = 0 %}
-{% for chapter in site.data.navigation.chapters %}
+{% for chapter in site.data.navigation.part0_intro %}
     {% if page.url contains chapter.path %}
         {% assign current_index = forloop.index %}
         {% break %}
@@ -136,9 +173,26 @@
 {% endfor %}
 
 {% if current_index == 0 %}
+{% for chapter in site.data.navigation.chapters %}
+    {% if page.url contains chapter.path %}
+        {% assign part0_size = 0 %}
+        {% if site.data.navigation.part0_intro %}
+            {% assign part0_size = site.data.navigation.part0_intro.size %}
+        {% endif %}
+        {% assign current_index = part0_size | plus: forloop.index %}
+        {% break %}
+    {% endif %}
+{% endfor %}
+{% endif %}
+
+{% if current_index == 0 %}
     {% for appendix in site.data.navigation.appendices %}
         {% if page.url contains appendix.path %}
-            {% assign current_index = site.data.navigation.chapters.size | plus: forloop.index %}
+            {% assign part0_size = 0 %}
+            {% if site.data.navigation.part0_intro %}
+                {% assign part0_size = site.data.navigation.part0_intro.size %}
+            {% endif %}
+            {% assign current_index = part0_size | plus: site.data.navigation.chapters.size | plus: forloop.index %}
             {% break %}
         {% endif %}
     {% endfor %}

--- a/scripts/build-simple.js
+++ b/scripts/build-simple.js
@@ -438,6 +438,7 @@ exclude:
   async generateNavigationData(srcDir, publicDir) {
     const navigationData = {
       introduction: [],
+      part0_intro: [],
       chapters: [],
       appendices: [],
       afterword: []
@@ -462,7 +463,7 @@ exclude:
       }
     }
 
-    // Process chapters
+    // Process Part 0 chapters (chapter00, chapter01-intro, chapter02-intro)
     const chaptersPath = path.join(srcDir, 'chapters');
     try {
       const chapters = await fs.readdir(chaptersPath, { withFileTypes: true });
@@ -481,10 +482,18 @@ exclude:
           const titleMatch = content.match(/^#\s+(.+)$/m);
           const title = titleMatch ? titleMatch[1] : `第${chapter.name.match(/\d+/)?.[0]}章`;
           
-          navigationData.chapters.push({
-            title: title,
-            path: `/chapters/${chapter.name}/`
-          });
+          // Check if this is a Part 0 chapter (chapter00, chapter01-intro, chapter02-intro)
+          if (chapter.name === 'chapter00' || chapter.name === 'chapter01-intro' || chapter.name === 'chapter02-intro') {
+            navigationData.part0_intro.push({
+              title: title,
+              path: `/chapters/${chapter.name}/`
+            });
+          } else {
+            navigationData.chapters.push({
+              title: title,
+              path: `/chapters/${chapter.name}/`
+            });
+          }
         } catch {
           // Skip if index.md doesn't exist
         }
@@ -551,6 +560,10 @@ exclude:
 introduction:
 ${navigationData.introduction.map(intro => `  - title: "${intro.title}"
     path: "${intro.path}"`).join('\n')}
+
+part0_intro:
+${navigationData.part0_intro.map(ch => `  - title: "${ch.title}"
+    path: "${ch.path}"`).join('\n')}
 
 chapters:
 ${navigationData.chapters.map(ch => `  - title: "${ch.title}"


### PR DESCRIPTION
## 根本原因の修正
`build-simple.js`の自動生成機能が第0部入門編を認識していなかった問題を修正。

## 変更内容

### build-simple.js
- `generateNavigationData()`に`part0_intro`セクション処理を追加
- `chapter00`, `chapter01-intro`, `chapter02-intro`を第0部として分類
- navigation.yml生成時に`part0_intro`セクションを含める

### sidebar-nav.html
- `part0_intro`セクションの表示処理を再追加（自動生成で削除されていた）
- 進捗インジケーターに第0部の3章を含める計算を修正

## 問題の経緯
1. PR #13で第0部コンテンツを作成
2. PR #14でsidebar-nav.htmlを修正
3. PR #15でnavigation.ymlを手動修正
4. しかし`build-simple.js`が実行されると手動修正が上書きされていた

この修正により、ビルド時に第0部が自動的に認識され、ナビゲーションに表示されるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)