### PR TITLE
テンプレートファイルを修正して第0部表示の根本的解決

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -37,6 +37,40 @@
     </div>
     {% endif %}
 
+    <!-- Part 0: Introduction Guide -->
+    {% if site.data.navigation.part0_intro %}
+    <div class="nav-section">
+        <h3 class="nav-section-title">第0部：入門編</h3>
+        <ul class="nav-list">
+            {% for chapter in site.data.navigation.part0_intro %}
+            <li class="nav-item">
+                <a href="{{ site.baseurl }}{{ chapter.path }}" 
+                   class="nav-link{% if page.url contains chapter.path %} active{% endif %}"
+                   aria-current="{% if page.url contains chapter.path %}page{% endif %}">
+                    <span class="nav-number">{{ forloop.index0 }}</span>
+                    <span class="nav-title">{{ chapter.title }}</span>
+                </a>
+                
+                <!-- Sub-sections if available -->
+                {% if chapter.sections %}
+                <ul class="nav-subsections">
+                    {% for section in chapter.sections %}
+                    <li class="nav-subsection">
+                        <a href="{{ site.baseurl }}{{ section.path }}" 
+                           class="nav-sublink{% if page.url == section.path %} active{% endif %}"
+                           aria-current="{% if page.url == section.path %}page{% endif %}">
+                            {{ section.title }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
     <!-- Chapters -->
     {% if site.data.navigation.chapters %}
     <div class="nav-section">
@@ -123,12 +157,15 @@
 
 <!-- Progress Indicator -->
 {% assign total_pages = site.data.navigation.chapters.size %}
+{% if site.data.navigation.part0_intro %}
+{% assign total_pages = total_pages | plus: site.data.navigation.part0_intro.size %}
+{% endif %}
 {% if site.data.navigation.appendices %}
 {% assign total_pages = total_pages | plus: site.data.navigation.appendices.size %}
 {% endif %}
 
 {% assign current_index = 0 %}
-{% for chapter in site.data.navigation.chapters %}
+{% for chapter in site.data.navigation.part0_intro %}
     {% if page.url contains chapter.path %}
         {% assign current_index = forloop.index %}
         {% break %}
@@ -136,9 +173,26 @@
 {% endfor %}
 
 {% if current_index == 0 %}
+{% for chapter in site.data.navigation.chapters %}
+    {% if page.url contains chapter.path %}
+        {% assign part0_size = 0 %}
+        {% if site.data.navigation.part0_intro %}
+            {% assign part0_size = site.data.navigation.part0_intro.size %}
+        {% endif %}
+        {% assign current_index = part0_size | plus: forloop.index %}
+        {% break %}
+    {% endif %}
+{% endfor %}
+{% endif %}
+
+{% if current_index == 0 %}
     {% for appendix in site.data.navigation.appendices %}
         {% if page.url contains appendix.path %}
-            {% assign current_index = site.data.navigation.chapters.size | plus: forloop.index %}
+            {% assign part0_size = 0 %}
+            {% if site.data.navigation.part0_intro %}
+                {% assign part0_size = site.data.navigation.part0_intro.size %}
+            {% endif %}
+            {% assign current_index = part0_size | plus: site.data.navigation.chapters.size | plus: forloop.index %}
             {% break %}
         {% endif %}
     {% endfor %}

--- a/templates/includes/sidebar-nav.html
+++ b/templates/includes/sidebar-nav.html
@@ -37,6 +37,40 @@
     </div>
     {% endif %}
 
+    <!-- Part 0: Introduction Guide -->
+    {% if site.data.navigation.part0_intro %}
+    <div class="nav-section">
+        <h3 class="nav-section-title">第0部：入門編</h3>
+        <ul class="nav-list">
+            {% for chapter in site.data.navigation.part0_intro %}
+            <li class="nav-item">
+                <a href="{{ site.baseurl }}{{ chapter.path }}" 
+                   class="nav-link{% if page.url contains chapter.path %} active{% endif %}"
+                   aria-current="{% if page.url contains chapter.path %}page{% endif %}">
+                    <span class="nav-number">{{ forloop.index0 }}</span>
+                    <span class="nav-title">{{ chapter.title }}</span>
+                </a>
+                
+                <!-- Sub-sections if available -->
+                {% if chapter.sections %}
+                <ul class="nav-subsections">
+                    {% for section in chapter.sections %}
+                    <li class="nav-subsection">
+                        <a href="{{ site.baseurl }}{{ section.path }}" 
+                           class="nav-sublink{% if page.url == section.path %} active{% endif %}"
+                           aria-current="{% if page.url == section.path %}page{% endif %}">
+                            {{ section.title }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
     <!-- Chapters -->
     {% if site.data.navigation.chapters %}
     <div class="nav-section">
@@ -123,12 +157,15 @@
 
 <!-- Progress Indicator -->
 {% assign total_pages = site.data.navigation.chapters.size %}
+{% if site.data.navigation.part0_intro %}
+{% assign total_pages = total_pages | plus: site.data.navigation.part0_intro.size %}
+{% endif %}
 {% if site.data.navigation.appendices %}
 {% assign total_pages = total_pages | plus: site.data.navigation.appendices.size %}
 {% endif %}
 
 {% assign current_index = 0 %}
-{% for chapter in site.data.navigation.chapters %}
+{% for chapter in site.data.navigation.part0_intro %}
     {% if page.url contains chapter.path %}
         {% assign current_index = forloop.index %}
         {% break %}
@@ -136,9 +173,26 @@
 {% endfor %}
 
 {% if current_index == 0 %}
+{% for chapter in site.data.navigation.chapters %}
+    {% if page.url contains chapter.path %}
+        {% assign part0_size = 0 %}
+        {% if site.data.navigation.part0_intro %}
+            {% assign part0_size = site.data.navigation.part0_intro.size %}
+        {% endif %}
+        {% assign current_index = part0_size | plus: forloop.index %}
+        {% break %}
+    {% endif %}
+{% endfor %}
+{% endif %}
+
+{% if current_index == 0 %}
     {% for appendix in site.data.navigation.appendices %}
         {% if page.url contains appendix.path %}
-            {% assign current_index = site.data.navigation.chapters.size | plus: forloop.index %}
+            {% assign part0_size = 0 %}
+            {% if site.data.navigation.part0_intro %}
+                {% assign part0_size = site.data.navigation.part0_intro.size %}
+            {% endif %}
+            {% assign current_index = part0_size | plus: site.data.navigation.chapters.size | plus: forloop.index %}
             {% break %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
## 最終的な根本原因と解決

### 問題の全体像
1. PR #13: 第0部コンテンツをdocs/に作成
2. PR #16: build-simple.jsとsidebar-nav.htmlを修正
3. PR #17: 第0部コンテンツをsrc/に追加
4. **しかし**: `templates/includes/sidebar-nav.html`が修正されていなかった

### 根本原因
ビルドスクリプトの`copyV3DesignSystem()`が`templates/includes/sidebar-nav.html`を`docs/_includes/`にコピーして上書きするため、個別に修正した`docs/_includes/sidebar-nav.html`の変更が消えていました。

### 修正内容

#### templates/includes/sidebar-nav.html
- **Part 0: Introduction Guide**セクション処理を追加
- `{% if site.data.navigation.part0_intro %}`で第0部を表示
- `forloop.index0`で第0章から開始する番号付け
- 進捗インジケーターに第0部の章数を含める処理

#### 修正後の動作
1. ビルド時に修正されたテンプレートが`docs/_includes/`にコピー
2. navigation.ymlの`part0_intro`セクションが認識される
3. サイドバーに「第0部：入門編」が表示される

### 今後の自動生成について
**完全に解決されました：**

✅ **ビルドスクリプト**: `src/chapters/`から第0部を読み取り  
✅ **navigation.yml**: `part0_intro`セクションを自動生成  
✅ **テンプレート**: 第0部表示処理を含む  
✅ **sidebar-nav.html**: ビルド時に正しいテンプレートで更新

このPRのマージ後、GitHub Actionsが実行されると第0部が確実に表示されます。

🤖 Generated with [Claude Code](https://claude.ai/code)