### PR TITLE
docs(nav): fix nonexistent links in sidebar

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -170,12 +170,12 @@
             <h3 class="toc-section-title">✨ リソース</h3>
             <ul class="toc-list">
                 <li class="toc-item">
-                    <a href="{{ '/src/appendix/' | relative_url }}" class="toc-link {% if page.url contains '/appendix/' %}active{% endif %}">
+                    <a href="{{ '/appendices/' | relative_url }}" class="toc-link {% if page.url contains '/appendix/' %}active{% endif %}">
                         付録
                     </a>
                 </li>
                 <li class="toc-item">
-                    <a href="{{ '/src/references/' | relative_url }}" class="toc-link {% if page.url contains '/references/' %}active{% endif %}">
+                    <a href="{{ '/appendices/appendix-c/' | relative_url }}" class="toc-link {% if page.url contains '/references/' %}active{% endif %}">
                         参考文献
                     </a>
                 </li>


### PR DESCRIPTION
- /src/appendix/ -> /appendices/\n- /src/references/ -> /appendices/appendix-c/