### PR TITLE
docs: add appendices index page

### DIFF
--- a/docs/appendices/index.md
+++ b/docs/appendices/index.md
@@ -1,0 +1,10 @@
+---
+layout: book
+title: 付録
+---
+
+# 付録
+
+- [付録A：コマンドリファレンス]({{ '/appendices/appendix-a/' | relative_url }})
+- [付録B：トラブルシューティングガイド]({{ '/appendices/appendix-b/' | relative_url }})
+- [付録C：リソース集]({{ '/appendices/appendix-c/' | relative_url }})


### PR DESCRIPTION
Add docs/appendices/index.md to avoid 404 and list A/B/C appendices.