### PR TITLE
fix: migration-guide のタイトル整合

### DIFF
--- a/docs/additional/migration-guide.md
+++ b/docs/additional/migration-guide.md
@@ -1,5 +1,5 @@
 ---
-title: "Docker→Podman移行ガイドライン"
+title: "Docker→Podman包括的移行ガイドライン"
 ---
 
 # Docker→Podman包括的移行ガイドライン


### PR DESCRIPTION
## 目的
ページナビゲーション等で参照される front matter `title` を、本文の見出し（H1）と一致させます。

## 変更点
- `docs/additional/migration-guide.md` のみ
  - `title` を `Docker→Podman包括的移行ガイドライン` に統一

## 影響
本文内容の変更はありません。
