### PR TITLE
fix: src migration-guide のタイトルをH1に整合

### DIFF
--- a/src/additional/migration-guide.md
+++ b/src/additional/migration-guide.md
@@ -1,5 +1,5 @@
 ---
-title: "Docker→Podman移行ガイドライン"
+title: "Docker→Podman包括的移行ガイドライン"
 ---
 
 # Docker→Podman包括的移行ガイドライン


### PR DESCRIPTION
目的: `src` 側のページタイトル（front matter）を本文H1に揃え、表示・参照時の混乱を減らす。

対応内容:
- `src/additional/migration-guide.md` の `title` を H1 に整合

背景:
- `docs/additional/migration-guide.md` は別PR（#109）で整合済みのため、今回 `src` 側のみ対応
