### PR TITLE
Remove docs/Gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,0 @@
-source "https://rubygems.org"
-
-gem "github-pages", group: :jekyll_plugins


### PR DESCRIPTION
方針: docs/ は公開用の書籍のみを配置する。

- docs/Gemfile を削除（root Gemfile が存在するため）
- 参照があれば docs/Gemfile -> Gemfile へ更新