### PR TITLE
apt-key廃止（keyring方式へ更新）

### DIFF
--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -85,7 +85,8 @@ $ . /etc/os-release
 $ sudo install -m 0755 -d /etc/apt/keyrings
 
 $ curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | \
-  sudo gpg --dearmor -o /etc/apt/keyrings/libcontainers.gpg
+  sudo gpg --dearmor --yes --batch -o /etc/apt/keyrings/libcontainers.gpg
+$ sudo chmod a+r /etc/apt/keyrings/libcontainers.gpg
 
 $ echo "deb [signed-by=/etc/apt/keyrings/libcontainers.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | \
   sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null

--- a/src/chapters/chapter03/index.md
+++ b/src/chapters/chapter03/index.md
@@ -83,7 +83,8 @@ $ . /etc/os-release
 $ sudo install -m 0755 -d /etc/apt/keyrings
 
 $ curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | \
-  sudo gpg --dearmor -o /etc/apt/keyrings/libcontainers.gpg
+  sudo gpg --dearmor --yes --batch -o /etc/apt/keyrings/libcontainers.gpg
+$ sudo chmod a+r /etc/apt/keyrings/libcontainers.gpg
 
 $ echo "deb [signed-by=/etc/apt/keyrings/libcontainers.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | \
   sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list > /dev/null


### PR DESCRIPTION
Ubuntu 22.04/24.04 の手順として、`apt-key`（非推奨）を使用しない keyring 方式へ更新しました。

- Kubic リポジトリ追加: `apt-key add` → `gpg --dearmor` + `signed-by=`
- 章見出し: 手順が Ubuntu 前提のため `Ubuntu/Debian` → `Ubuntu` に修正

対象:
- `docs/chapters/chapter03/index.md`
- `src/chapters/chapter03/index.md`
