### PR TITLE
fix(docs): update Node.js image label in diagram

### DIFF
--- a/docs/assets/images/diagrams/chapter01-docker-compose-vs-podman-pod.svg
+++ b/docs/assets/images/diagrams/chapter01-docker-compose-vs-podman-pod.svg
@@ -148,7 +148,7 @@
   
   <rect class="docker-container" x="220" y="140" width="100" height="60" />
   <text x="270" y="165" class="text">app</text>
-  <text x="270" y="180" class="small-text">node:16</text>
+  <text x="270" y="180" class="small-text">node:20</text>
   
   <rect class="docker-container" x="80" y="220" width="100" height="60" />
   <text x="130" y="245" class="text">db</text>
@@ -191,7 +191,7 @@
   
   <rect class="podman-container" x="480" y="200" width="100" height="60" />
   <text x="530" y="225" class="text">app</text>
-  <text x="530" y="240" class="small-text">node:16</text>
+  <text x="530" y="240" class="small-text">node:20</text>
   
   <rect class="podman-container" x="600" y="200" width="100" height="60" />
   <text x="650" y="225" class="text">db</text>


### PR DESCRIPTION
# 変更内容
- 図表（Docker Compose vs Podman Pod）のラベルを更新
  - `node:16` → `node:20`

対象ファイル:
- `docs/assets/images/diagrams/chapter01-docker-compose-vs-podman-pod.svg`

# 背景
- Node.js 16 はEOLであり、シリーズ全体の前提（Node.js 20+）と不整合でした。

# 関連
- itdojp/it-engineer-knowledge-architecture Issue #102
