### PR TITLE
CI記述例の GitHub Actions バージョンを v4 に更新

### DIFF
--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -273,7 +273,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Podman
         run: |

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -271,7 +271,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Set up Podman
         run: |


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- CI 記述例の `actions/checkout@v3` を `actions/checkout@v4` に更新
- `src` / `docs` の重複管理ファイルを同期更新
