### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -310,7 +310,7 @@ jobs:
           podman run --rm ${{ env.IMAGE_NAME }}:${{ github.sha }} npm test
       
       - name: Security scan with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: 'sarif'  # GitHub Security タブ統合

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -308,7 +308,7 @@ jobs:
           podman run --rm ${{ env.IMAGE_NAME }}:${{ github.sha }} npm test
       
       - name: Security scan with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: 'sarif'  # GitHub Security タブ統合


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- aquasecurity/trivy-action@master -> aquasecurity/trivy-action@0.33.1

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102