### PR TITLE
CI記述例の codeql-action 参照を v4 に更新

### DIFF
--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -317,7 +317,7 @@ jobs:
           output: 'trivy-results.sarif'
       
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
         # GitHub Security タブでの可視化

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -315,7 +315,7 @@ jobs:
           output: 'trivy-results.sarif'
       
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
         # GitHub Security タブでの可視化


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残る `github/codeql-action@v2` 系参照を `@v4` に更新

## 変更内容
- `github/codeql-action/init@v2` -> `@v4`
- `github/codeql-action/analyze@v2` -> `@v4`
- `github/codeql-action/upload-sarif@v2` -> `@v4`
- `github/codeql-action/autobuild@v2` -> `@v4`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
