### PR TITLE
ci: actions/setup-node を v6 に更新（workflow）

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
           path: book-formatter
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
         cache: 'npm'


### PR DESCRIPTION
- `.github/workflows/book-qa.yml` と `.github/workflows/build.yml` の `actions/setup-node@v4` を `@v6` に更新
- 変更範囲は workflow 定義のみ

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102