### PR TITLE
fix(docs): replace appendix placeholders

### DIFF
--- a/docs/appendices/appendix-b/index.md
+++ b/docs/appendices/appendix-b/index.md
@@ -6,13 +6,31 @@ title: "付録B：トラブルシューティングガイド"
 
 # 付録B：トラブルシューティングガイド
 
-*この付録は準備中です。*
+本付録は、運用時の一次切り分けで頻出する確認ポイントと、詳細ガイドへの導線をまとめます。
 
-## 内容予定：
-- よくある問題と解決策
-- エラーメッセージ一覧
-- デバッグ手順
-- パフォーマンスチューニング
-- リソース制限の問題
+- 詳細ガイド: [Podman実践的トラブルシューティングガイド](../../additional/troubleshooting-guide/)
+- 参考: [Docker→Podman包括的移行ガイドライン](../../additional/migration-guide/)
+
+## まず確認する（一次切り分け）
+
+```bash
+podman version
+podman info
+podman ps -a
+podman logs <container>
+podman inspect <container>
+podman events --since 10m
+```
+
+## よくある原因（抜粋）
+
+- 権限/SELinux: rootless/SELinux の影響でマウントや実行が失敗することがある
+- ネットワーク: rootless のネットワーク実装（slirp4netns 等）や DNS 設定が原因になることがある
+- レジストリ/認証: pull 失敗はレジストリ設定や認証、プロキシが原因になりやすい
+- ストレージ/容量: イメージ/レイヤ増加で容量逼迫しやすい（`podman system df` で把握）
+
+## エラーメッセージの扱い
+
+- `podman` の出力に加え、必要に応じて `journalctl`（systemd 管理時）やアプリケーションログも併せて確認する
 
 ---

--- a/docs/appendices/appendix-c/index.md
+++ b/docs/appendices/appendix-c/index.md
@@ -6,13 +6,20 @@ title: "付録C：参考リンク集"
 
 # 付録C：参考リンク集
 
-*この付録は準備中です。*
+本付録は、本書で扱う周辺ツール/公式情報へのリンクをまとめます。
 
-## 内容予定：
-- 公式ドキュメント
-- コミュニティリソース
-- 関連プロジェクト
-- 学習リソース
-- ツールとユーティリティ
+## 本書内の補足資料
+
+- [Docker→Podman包括的移行ガイドライン](../../additional/migration-guide/)
+- [Podman実践的トラブルシューティングガイド](../../additional/troubleshooting-guide/)
+
+## 公式/プロジェクト
+
+- Podman: https://podman.io/
+- Podman docs: https://docs.podman.io/
+- Podman (GitHub): https://github.com/containers/podman
+- Buildah (GitHub): https://github.com/containers/buildah
+- Skopeo (GitHub): https://github.com/containers/skopeo
+- containers/common (GitHub): https://github.com/containers/common
 
 ---

--- a/src/appendices/appendix-b/index.md
+++ b/src/appendices/appendix-b/index.md
@@ -4,13 +4,31 @@ title: "付録B：トラブルシューティングガイド"
 
 # 付録B：トラブルシューティングガイド
 
-*この付録は準備中です。*
+本付録は、運用時の一次切り分けで頻出する確認ポイントと、詳細ガイドへの導線をまとめます。
 
-## 内容予定：
-- よくある問題と解決策
-- エラーメッセージ一覧
-- デバッグ手順
-- パフォーマンスチューニング
-- リソース制限の問題
+- 詳細ガイド: [Podman実践的トラブルシューティングガイド](../../additional/troubleshooting-guide/)
+- 参考: [Docker→Podman包括的移行ガイドライン](../../additional/migration-guide/)
+
+## まず確認する（一次切り分け）
+
+```bash
+podman version
+podman info
+podman ps -a
+podman logs <container>
+podman inspect <container>
+podman events --since 10m
+```
+
+## よくある原因（抜粋）
+
+- 権限/SELinux: rootless/SELinux の影響でマウントや実行が失敗することがある
+- ネットワーク: rootless のネットワーク実装（slirp4netns 等）や DNS 設定が原因になることがある
+- レジストリ/認証: pull 失敗はレジストリ設定や認証、プロキシが原因になりやすい
+- ストレージ/容量: イメージ/レイヤ増加で容量逼迫しやすい（`podman system df` で把握）
+
+## エラーメッセージの扱い
+
+- `podman` の出力に加え、必要に応じて `journalctl`（systemd 管理時）やアプリケーションログも併せて確認する
 
 ---

--- a/src/appendices/appendix-c/index.md
+++ b/src/appendices/appendix-c/index.md
@@ -4,13 +4,20 @@ title: "付録C：参考リンク集"
 
 # 付録C：参考リンク集
 
-*この付録は準備中です。*
+本付録は、本書で扱う周辺ツール/公式情報へのリンクをまとめます。
 
-## 内容予定：
-- 公式ドキュメント
-- コミュニティリソース
-- 関連プロジェクト
-- 学習リソース
-- ツールとユーティリティ
+## 本書内の補足資料
+
+- [Docker→Podman包括的移行ガイドライン](../../additional/migration-guide/)
+- [Podman実践的トラブルシューティングガイド](../../additional/troubleshooting-guide/)
+
+## 公式/プロジェクト
+
+- Podman: https://podman.io/
+- Podman docs: https://docs.podman.io/
+- Podman (GitHub): https://github.com/containers/podman
+- Buildah (GitHub): https://github.com/containers/buildah
+- Skopeo (GitHub): https://github.com/containers/skopeo
+- containers/common (GitHub): https://github.com/containers/common
 
 ---


### PR DESCRIPTION
付録B/付録Cの『準備中』プレースホルダを、実務で参照しやすい最小構成の内容（一次切り分け手順・参照リンク）に置換しました。\n\n- 変更: docs/src を整合\n- 影響: 表示上の本文のみ（CI/ビルド定義の変更なし）