### PR TITLE
chore(svg): normalize font-family stacks

### DIFF
--- a/docs/assets/images/diagrams/chapter00-container-runtime-structure.svg
+++ b/docs/assets/images/diagrams/chapter00-container-runtime-structure.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter00-container-vs-vm-resource-usage.svg
+++ b/docs/assets/images/diagrams/chapter00-container-vs-vm-resource-usage.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter00-oci-ecosystem.svg
+++ b/docs/assets/images/diagrams/chapter00-oci-ecosystem.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter01-docker-compose-vs-podman-pod.svg
+++ b/docs/assets/images/diagrams/chapter01-docker-compose-vs-podman-pod.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter01-multi-arch-build-process.svg
+++ b/docs/assets/images/diagrams/chapter01-multi-arch-build-process.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter01-podman-compose-workflow.svg
+++ b/docs/assets/images/diagrams/chapter01-podman-compose-workflow.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter01-windows-wsl2-environment.svg
+++ b/docs/assets/images/diagrams/chapter01-windows-wsl2-environment.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-container-security-layers.svg
+++ b/docs/assets/images/diagrams/chapter02-container-security-layers.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-network-configuration-options.svg
+++ b/docs/assets/images/diagrams/chapter02-network-configuration-options.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       
@@ -139,7 +139,7 @@
         fill: var(--text-color);
         font-size: 9px;
         font-weight: 400;
-        font-family: 'Monaco', 'Menlo', monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         text-anchor: middle;
       }
       

--- a/docs/assets/images/diagrams/chapter02-pod-lifecycle-management.svg
+++ b/docs/assets/images/diagrams/chapter02-pod-lifecycle-management.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       
@@ -110,7 +110,7 @@
         fill: var(--text-color);
         font-size: 10px;
         font-weight: 400;
-        font-family: 'Monaco', 'Menlo', monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         text-anchor: middle;
       }
       

--- a/docs/assets/images/diagrams/chapter02-pull-operation-internal.svg
+++ b/docs/assets/images/diagrams/chapter02-pull-operation-internal.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-rootless-uid-gid-mapping.svg
+++ b/docs/assets/images/diagrams/chapter02-rootless-uid-gid-mapping.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-security-context-flow.svg
+++ b/docs/assets/images/diagrams/chapter02-security-context-flow.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-troubleshooting-flowchart.svg
+++ b/docs/assets/images/diagrams/chapter02-troubleshooting-flowchart.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter02-volume-mount-types.svg
+++ b/docs/assets/images/diagrams/chapter02-volume-mount-types.svg
@@ -24,7 +24,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       
@@ -115,7 +115,7 @@
         fill: var(--text-color);
         font-size: 9px;
         font-weight: 400;
-        font-family: 'Monaco', 'Menlo', monospace;
+        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
         text-anchor: middle;
       }
       

--- a/docs/assets/images/diagrams/chapter04-container-lifecycle-states.svg
+++ b/docs/assets/images/diagrams/chapter04-container-lifecycle-states.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter06-podman-network-architecture.svg
+++ b/docs/assets/images/diagrams/chapter06-podman-network-architecture.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/chapter08-security-layer-architecture.svg
+++ b/docs/assets/images/diagrams/chapter08-security-layer-architecture.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/docs/assets/images/diagrams/docker-podman-detailed-architecture-comparison.svg
+++ b/docs/assets/images/diagrams/docker-podman-detailed-architecture-comparison.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .arch-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .component-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .arch-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .component-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .docker-box { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
       .podman-box { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
       .daemon-box { fill: var(--svg-error); stroke: var(--svg-error); stroke-width: 2; }

--- a/docs/assets/images/diagrams/linux-namespaces-cgroups-visualization.svg
+++ b/docs/assets/images/diagrams/linux-namespaces-cgroups-visualization.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .section-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .namespace-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .section-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .namespace-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .host-box { fill: var(--svg-neutral); stroke: var(--svg-neutral); stroke-width: 2; }
       .namespace-box { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
       .cgroup-box { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }

--- a/docs/assets/images/diagrams/multi-stage-build-layer-visualization.svg
+++ b/docs/assets/images/diagrams/multi-stage-build-layer-visualization.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .stage-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .layer-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .stage-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .layer-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .build-stage { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
       .runtime-stage { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
       .base-layer { fill: var(--svg-neutral); stroke: var(--svg-neutral); stroke-width: 1; }

--- a/docs/assets/images/diagrams/pod-architecture.svg
+++ b/docs/assets/images/diagrams/pod-architecture.svg
@@ -2,10 +2,10 @@
 <svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title-text { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .pod-title { font-family: 'Noto Sans JP', sans-serif; font-size: 16px; font-weight: bold; fill: #34495e; }
-      .container-text { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; fill: #2c3e50; }
-      .namespace-text { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #7f8c8d; font-style: italic; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .pod-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: bold; fill: #34495e; }
+      .container-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #2c3e50; }
+      .namespace-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #7f8c8d; font-style: italic; }
       .pod-boundary { fill: #f8f9fa; stroke: #2c3e50; stroke-width: 3; stroke-dasharray: 10,5; }
       .infra-container { fill: #e6f3ff; stroke: #3498db; stroke-width: 2; }
       .app-container { fill: #fff; stroke: #34495e; stroke-width: 2; }

--- a/docs/assets/images/diagrams/pod-shared-namespaces-architecture.svg
+++ b/docs/assets/images/diagrams/pod-shared-namespaces-architecture.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .pod-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .namespace-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .pod-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .namespace-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .pod-boundary { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 3; }
       .infra-container { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
       .app-container { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }

--- a/docs/assets/images/diagrams/podman-architecture.svg
+++ b/docs/assets/images/diagrams/podman-architecture.svg
@@ -2,10 +2,10 @@
 <svg width="900" height="700" viewBox="0 0 900 700" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title-text { font-family: 'Noto Sans JP', sans-serif; font-size: 20px; font-weight: bold; fill: #2c3e50; }
-      .subtitle-text { font-family: 'Noto Sans JP', sans-serif; font-size: 16px; font-weight: bold; fill: #34495e; }
-      .component-text { font-family: 'Noto Sans JP', sans-serif; font-size: 12px; fill: #2c3e50; }
-      .label-text { font-family: 'Noto Sans JP', sans-serif; font-size: 11px; fill: #7f8c8d; }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 20px; font-weight: bold; fill: #2c3e50; }
+      .subtitle-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: bold; fill: #34495e; }
+      .component-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; fill: #2c3e50; }
+      .label-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 11px; fill: #7f8c8d; }
       .docker-area { fill: #ffe6e6; stroke: #e74c3c; stroke-width: 2; }
       .podman-area { fill: #e6ffe6; stroke: #27ae60; stroke-width: 2; }
       .component-box { fill: #fff; stroke: #34495e; stroke-width: 2; rx: 5; }

--- a/docs/assets/images/diagrams/podman-kubernetes-migration-pathway.svg
+++ b/docs/assets/images/diagrams/podman-kubernetes-migration-pathway.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .phase-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .step-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .phase-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .step-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .phase1-box { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
       .phase2-box { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
       .phase3-box { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
@@ -128,12 +128,12 @@
     <!-- Generated YAML Example -->
     <rect x="100" y="350" width="620" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
     <text x="400" y="365" class="step-text" text-anchor="middle" font-weight="500">生成されるKubernetes YAML例</text>
-    <text x="120" y="380" class="annotation-text" font-family="monospace">apiVersion: v1</text>
-    <text x="120" y="395" class="annotation-text" font-family="monospace">kind: Pod</text>
-    <text x="120" y="410" class="annotation-text" font-family="monospace">metadata: {name: web-app}</text>
-    <text x="400" y="380" class="annotation-text" font-family="monospace">spec:</text>
-    <text x="400" y="395" class="annotation-text" font-family="monospace">  containers: [...nginx, app...]</text>
-    <text x="400" y="410" class="annotation-text" font-family="monospace">  restartPolicy: OnFailure</text>
+    <text x="120" y="380" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">apiVersion: v1</text>
+    <text x="120" y="395" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">kind: Pod</text>
+    <text x="120" y="410" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">metadata: {name: web-app}</text>
+    <text x="400" y="380" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">spec:</text>
+    <text x="400" y="395" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">  containers: [...nginx, app...]</text>
+    <text x="400" y="410" class="annotation-text" font-family="'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace">  restartPolicy: OnFailure</text>
   </g>
 
   <!-- Generation Flow Arrows -->

--- a/docs/assets/images/diagrams/rootless-vs-root-container-execution.svg
+++ b/docs/assets/images/diagrams/rootless-vs-root-container-execution.svg
@@ -13,10 +13,10 @@
         --svg-error: #dc2626;
         --svg-neutral: #6b7280;
       }
-      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
-      .mode-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
-      .layer-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
-      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .mode-title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .layer-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
       .root-box { fill: var(--svg-error); stroke: var(--svg-error); stroke-width: 2; }
       .rootless-box { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
       .mapping-box { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }


### PR DESCRIPTION
## 変更内容
SVG 図表内の `font-family` 指定を、書籍共通のフォントスタック（`--font-sans` / `--font-mono` 相当）に統一しました。

- 対象: `docs/**/*.svg`
- 実行: `book-formatter/scripts/svg-font-normalize.js docs --apply`

## 補足
このPRは SVG 内の `font-family` のみを機械的に正規化しています（図形/レイアウトには触れていません）。
