### PR TITLE
chore(svg): normalize font stacks in diagrams

### DIFF
--- a/docs/assets/images/diagrams/chapter00-virtualization-architecture-comparison.svg
+++ b/docs/assets/images/diagrams/chapter00-virtualization-architecture-comparison.svg
@@ -1,11 +1,11 @@
 <svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 700 18px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); }
-      .section-title { font: 600 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); }
-      .layer-text { font: 500 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); }
-      .app-text { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #4a5568); }
-      .legend-text { font: 400 11px Inter, sans-serif; fill: var(--color-text-secondary, #4a5568); }
+      .title { font: 700 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); }
+      .section-title { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); }
+      .layer-text { font: 500 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); }
+      .app-text { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #4a5568); }
+      .legend-text { font: 400 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #4a5568); }
       
       .bare-metal { fill: var(--color-gray-100, #f7fafc); stroke: var(--color-gray-300, #cbd5e0); }
       .vm-layer { fill: var(--color-blue-50, #ebf8ff); stroke: var(--color-blue-200, #90cdf4); }

--- a/docs/assets/images/diagrams/chapter01-docker-podman-architecture.svg
+++ b/docs/assets/images/diagrams/chapter01-docker-podman-architecture.svg
@@ -1,10 +1,10 @@
 <svg width="700" height="500" viewBox="0 0 700 500" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .subtitle { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: middle; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .subtitle { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: middle; }
       .box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-border, #e2e8f0); stroke-width: 2; rx: 8; }
       .cli-box { fill: var(--color-blue-50, #ebf8ff); stroke: var(--color-blue-200, #90cdf4); stroke-width: 2; rx: 8; }
       .daemon-box { fill: var(--color-red-50, #fed7d7); stroke: var(--color-red-200, #fc8181); stroke-width: 2; rx: 8; }

--- a/docs/assets/images/diagrams/chapter02-container-execution-process.svg
+++ b/docs/assets/images/diagrams/chapter02-container-execution-process.svg
@@ -1,10 +1,10 @@
 <svg width="900" height="800" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .section-title { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: start; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .section-title { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: start; }
       .step-box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-border, #e2e8f0); stroke-width: 2; rx: 8; }
       .check-box { fill: var(--color-blue-50, #ebf8ff); stroke: var(--color-blue-200, #90cdf4); stroke-width: 2; rx: 6; }
       .namespace-box { fill: var(--color-green-50, #f0fff4); stroke: var(--color-green-200, #9ae6b4); stroke-width: 2; rx: 6; }
@@ -13,7 +13,7 @@
       .network-box { fill: var(--color-cyan-50, #ecfeff); stroke: var(--color-cyan-200, #67e8f9); stroke-width: 2; rx: 6; }
       .process-box { fill: var(--color-red-50, #fef2f2); stroke: var(--color-red-200, #fca5a5); stroke-width: 2; rx: 6; }
       .arrow { stroke: var(--color-gray-600, #718096); stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
-      .step-number { font: 600 14px Inter, sans-serif; fill: var(--color-primary, #3182ce); }
+      .step-number { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-primary, #3182ce); }
     </style>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-gray-600, #718096)" />

--- a/docs/assets/images/diagrams/chapter02-pod-internal-architecture.svg
+++ b/docs/assets/images/diagrams/chapter02-pod-internal-architecture.svg
@@ -1,11 +1,11 @@
 <svg width="750" height="600" viewBox="0 0 750 600" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .section-title { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: start; }
-      .shared-note { font: 500 12px Inter, sans-serif; fill: var(--color-primary, #3182ce); text-anchor: middle; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .section-title { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: start; }
+      .shared-note { font: 500 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-primary, #3182ce); text-anchor: middle; }
       .pod-box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-primary, #3182ce); stroke-width: 3; rx: 12; }
       .infra-box { fill: var(--color-amber-50, #fffbeb); stroke: var(--color-amber-400, #fbbf24); stroke-width: 2; rx: 8; }
       .app-box { fill: var(--color-green-50, #f0fff4); stroke: var(--color-green-400, #38a169); stroke-width: 2; rx: 8; }
@@ -82,5 +82,5 @@
 
   <!-- Pod name label -->
   <rect x="620" y="65" width="70" height="20" fill="var(--color-primary, #3182ce)" rx="4"/>
-  <text x="655" y="78" style="font: 500 10px Inter, sans-serif; fill: white; text-anchor: middle;">webapp</text>
+  <text x="655" y="78" style="font: 500 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: white; text-anchor: middle;">webapp</text>
 </svg>

--- a/src/assets/images/diagrams/chapter01-docker-podman-architecture.svg
+++ b/src/assets/images/diagrams/chapter01-docker-podman-architecture.svg
@@ -1,10 +1,10 @@
 <svg width="700" height="500" viewBox="0 0 700 500" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .subtitle { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: middle; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .subtitle { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: middle; }
       .box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-border, #e2e8f0); stroke-width: 2; rx: 8; }
       .cli-box { fill: var(--color-blue-50, #ebf8ff); stroke: var(--color-blue-200, #90cdf4); stroke-width: 2; rx: 8; }
       .daemon-box { fill: var(--color-red-50, #fed7d7); stroke: var(--color-red-200, #fc8181); stroke-width: 2; rx: 8; }

--- a/src/assets/images/diagrams/chapter02-container-execution-process.svg
+++ b/src/assets/images/diagrams/chapter02-container-execution-process.svg
@@ -1,10 +1,10 @@
 <svg width="900" height="800" viewBox="0 0 900 800" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .section-title { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: start; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .section-title { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: start; }
       .step-box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-border, #e2e8f0); stroke-width: 2; rx: 8; }
       .check-box { fill: var(--color-blue-50, #ebf8ff); stroke: var(--color-blue-200, #90cdf4); stroke-width: 2; rx: 6; }
       .namespace-box { fill: var(--color-green-50, #f0fff4); stroke: var(--color-green-200, #9ae6b4); stroke-width: 2; rx: 6; }
@@ -13,7 +13,7 @@
       .network-box { fill: var(--color-cyan-50, #ecfeff); stroke: var(--color-cyan-200, #67e8f9); stroke-width: 2; rx: 6; }
       .process-box { fill: var(--color-red-50, #fef2f2); stroke: var(--color-red-200, #fca5a5); stroke-width: 2; rx: 6; }
       .arrow { stroke: var(--color-gray-600, #718096); stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
-      .step-number { font: 600 14px Inter, sans-serif; fill: var(--color-primary, #3182ce); }
+      .step-number { font: 600 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-primary, #3182ce); }
     </style>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="var(--color-gray-600, #718096)" />

--- a/src/assets/images/diagrams/chapter02-pod-internal-architecture.svg
+++ b/src/assets/images/diagrams/chapter02-pod-internal-architecture.svg
@@ -1,11 +1,11 @@
 <svg width="750" height="600" viewBox="0 0 750 600" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style>
-      .title { font: 600 16px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .section-title { font: 500 14px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
-      .label { font: 400 12px Inter, sans-serif; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
-      .note { font: 400 10px Inter, sans-serif; fill: var(--color-text-secondary, #718096); text-anchor: start; }
-      .shared-note { font: 500 12px Inter, sans-serif; fill: var(--color-primary, #3182ce); text-anchor: middle; }
+      .title { font: 600 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .section-title { font: 500 14px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: middle; }
+      .label { font: 400 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-primary, #1a202c); text-anchor: start; }
+      .note { font: 400 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-text-secondary, #718096); text-anchor: start; }
+      .shared-note { font: 500 12px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: var(--color-primary, #3182ce); text-anchor: middle; }
       .pod-box { fill: var(--color-bg-secondary, #f7fafc); stroke: var(--color-primary, #3182ce); stroke-width: 3; rx: 12; }
       .infra-box { fill: var(--color-amber-50, #fffbeb); stroke: var(--color-amber-400, #fbbf24); stroke-width: 2; rx: 8; }
       .app-box { fill: var(--color-green-50, #f0fff4); stroke: var(--color-green-400, #38a169); stroke-width: 2; rx: 8; }
@@ -82,5 +82,5 @@
 
   <!-- Pod name label -->
   <rect x="620" y="65" width="70" height="20" fill="var(--color-primary, #3182ce)" rx="4"/>
-  <text x="655" y="78" style="font: 500 10px Inter, sans-serif; fill: white; text-anchor: middle;">webapp</text>
+  <text x="655" y="78" style="font: 500 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'; fill: white; text-anchor: middle;">webapp</text>
 </svg>

--- a/src/assets/images/diagrams/chapter04-container-lifecycle-states.svg
+++ b/src/assets/images/diagrams/chapter04-container-lifecycle-states.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/src/assets/images/diagrams/chapter06-podman-network-architecture.svg
+++ b/src/assets/images/diagrams/chapter06-podman-network-architecture.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       

--- a/src/assets/images/diagrams/chapter08-security-layer-architecture.svg
+++ b/src/assets/images/diagrams/chapter08-security-layer-architecture.svg
@@ -26,7 +26,7 @@
       }
       
       .diagram {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
         background: var(--bg-color);
       }
       


### PR DESCRIPTION
SVG 図表内のフォント指定（font / font-family）を book-formatter の共通スタックへ正規化します。

- 既存の `font: ... Inter, sans-serif` / `font: ... sans-serif` を共通スタックへ置換
- `docs/` と `src/` の SVG を対象

関連: it-engineer-knowledge-architecture Issue #19