### PR TITLE
モバイル表示の横スクロールを抑止

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -218,5 +218,21 @@
         });
     </script>
 
+    <script>
+        // Wrap tables so they can scroll horizontally on small screens without affecting page-wide overflow.
+        document.addEventListener('DOMContentLoaded', function() {
+            var tables = document.querySelectorAll('.book-content table');
+            for (var i = 0; i < tables.length; i++) {
+                var table = tables[i];
+                if (!table || !table.parentNode) continue;
+                if (table.parentElement && table.parentElement.classList.contains('table-wrapper')) continue;
+                var wrapper = document.createElement('div');
+                wrapper.className = 'table-wrapper';
+                table.parentNode.insertBefore(wrapper, table);
+                wrapper.appendChild(table);
+            }
+        });
+    </script>
+
 </body>
 </html>

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -23,17 +23,23 @@ html {
 
 /* Mobile/Tablet Implementation (≤1024px) */
 @media (max-width: 1024px) {
-  /* Avoid subtle global horizontal scrolling on small screens. */
-  html, body {
+  /* Avoid subtle horizontal scrolling on small screens by constraining the main content area. */
+  .book-layout .book-main {
     overflow-x: hidden;
   }
 
   /* Keep wide tables scrollable without expanding the whole page width. */
-  .book-content table {
+  .book-content .table-wrapper {
     display: block;
     max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+  }
+
+  .book-content .table-wrapper table {
+    min-width: 100%;
+    width: max-content;
+    table-layout: auto;
   }
 
   /* Full-width content layout */


### PR DESCRIPTION
## 背景
モバイル幅で一部ページに微小な横スクロール（`scrollWidth > clientWidth`）が発生していました。

主因:
- CSS-only サイドバー用の hidden checkbox（既定サイズが残る）
- 画面幅を超える table が全体幅を押し広げる
- 一部コードブロック由来の微小オーバーフロー（横スクロール自体は code/pre の内部で行うのが望ましい）

## 対応
- `docs/assets/css/mobile-responsive.css`
  - `.sidebar-toggle-checkbox` に `width/height: 0` を追加
  - `@media (max-width: 1024px)` で `html, body { overflow-x: hidden; }` を追加
  - `table` を `display:block + overflow-x:auto` にし、ページ全体の横幅拡張を防止

## 期待される効果
- モバイルでの不要な横スクロールを抑止し、表は要素内スクロールで閲覧可能になります。
