### PR TITLE
Fix mobile horizontal overflow (assets)

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -6,8 +6,19 @@
 /* Hidden checkbox for state management */
 .sidebar-toggle-checkbox {
   position: absolute;
-  left: -9999px;
+  top: 0;
+  left: 0;
   opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  pointer-events: none;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
 }
 
 /* Prevent page jumping and unwanted focus */
@@ -25,12 +36,28 @@ html {
   .book-layout .book-main {
     margin-left: 0 !important;
     width: 100% !important;
+    /* Constrain page-wide overflow; scroll should be inside dedicated containers. */
+    overflow-x: hidden;
   }
   
   .book-layout .book-main .book-content {
     margin: 0 !important;
     padding-left: 1rem !important;
     padding-right: 1rem !important;
+  }
+
+  /* Keep wide tables scrollable without expanding the whole page width. */
+  .book-content .table-wrapper {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .book-content .table-wrapper table {
+    min-width: 100%;
+    width: max-content;
+    table-layout: auto;
   }
   
   /* Show hamburger menu */


### PR DESCRIPTION
Pages Visual Check で podman-book の mobile 表示に横スクロール警告が残っていたため、ビルド成果物に反映される assets 側の CSS を修正します。

変更点
- sidebar-toggle-checkbox を off-screen 配置（left:-9999px）から clip/clip-path に変更し、ページ全体の横溢れを防止
- mobile(<=1024px) で .book-layout .book-main に overflow-x: hidden を付与
- .table-wrapper に overflow-x: auto を付与し、表の横スクロールをコンテナ内に閉じ込め

補足
- 本リポジトリは Node build で assets/ が docs/assets/ を上書きするため、修正は assets/css/mobile-responsive.css 側に入れる必要があります。