### PR TITLE
第11章: スコープと podman kube play 制約を明記 (#174)

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -10,7 +10,7 @@ title: "第11章：Kubernetesとの統合"
 >
 > - 本章は **Podman と Kubernetes の相互運用**（Kubernetes YAML の生成／簡易実行）を扱います。
 > - **Kubernetes の設計・運用（クラスタ構成、Service/Ingress、スケジューリング、RBAC、ローリング更新等）の学習は対象外** です。
-> - `podman kube play` は Kubernetes を完全再現しません。特に **Service/Ingress、複数レプリカ、readiness/startup probe 等** は差分があるため、**本番相当の挙動確認は実クラスタで実施** してください（差分は後述）。
+> - `podman kube play` は Kubernetes を完全再現しません（`podman play kube` は同義のエイリアスです）。特に **Service/Ingress、複数レプリカ、readiness/startup probe 等** は差分があるため、**本番相当の挙動確認は実クラスタで実施** してください（差分は後述）。
 
 ## 本章の意義と学習目標
 

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -1,14 +1,14 @@
 ---
-title: "第13章 Kubernetes連携"
+title: "第11章 Kubernetes連携"
 ---
 
-# 第13章 Kubernetes連携
+# 第11章 Kubernetes連携
 
 > **注意（この章のスコープ）**
 >
 > - 本章は **Podman と Kubernetes の相互運用**（Kubernetes YAML の生成／簡易実行）を扱います。
 > - **Kubernetes の設計・運用（クラスタ構成、Service/Ingress、スケジューリング、RBAC、ローリング更新等）の学習は対象外** です。
-> - `podman kube play` は Kubernetes を完全再現しません。特に **Service/Ingress、複数レプリカ、readiness/startup probe 等** は差分があるため、**本番相当の挙動確認は実クラスタで実施** してください（差分は後述）。
+> - `podman kube play` は Kubernetes を完全再現しません（`podman play kube` は同義のエイリアスです）。特に **Service/Ingress、複数レプリカ、readiness/startup probe 等** は差分があるため、**本番相当の挙動確認は実クラスタで実施** してください（差分は後述）。
 
 ## 本章の意義と学習目標
 


### PR DESCRIPTION
Issue #174 対応（最小改訂）。

- 章冒頭に「注意（この章のスコープ）」を追加し、Kubernetes学習教材/代替ではない旨と `podman kube play` の非互換前提を明記
- 断定表現を緩和し、YAMLの簡易検証/差分低減の位置付けに調整
- `podman kube play` の supported kinds / 制約（replicas=1、readiness/startup未対応等）を追記・強調
- `minikube --driver=podman` の experimental 注記を追記

動作確認:
- `npm ci`
- `npm run build`

Closes #174
