### PR TITLE
第11章: 追加改善（コマンド統一/Kind手順/Quadlet注記） (#176)

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -109,7 +109,7 @@ podman generate systemd --name iot-collector --files
 systemctl --user enable container-iot-collector.service
 ```
 
-※ `podman generate systemd` は非推奨です。systemd連携は Quadlet（例: `.container`）を推奨します。
+※ `podman generate systemd` は非推奨（deprecated）です。今後の systemd 連携は Quadlet（例: `.container` ユニット）による管理を前提にしてください。
 
 **効果：**
 - メモリ使用量: 30%削減
@@ -472,13 +472,12 @@ kubectl run myapp --image=myapp:dev --image-pull-policy=Never
 
 ```bash
 # クラスター作成（rootless Podman provider; 公式推奨）
-export KIND_EXPERIMENTAL_PROVIDER=podman
-kind create cluster
+KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 
 # 一部環境では systemd-run が必要（公式docsの記載）
-systemd-run --scope --user kind create cluster
+systemd-run --scope --user env KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 # まだエラーが出る場合
-systemd-run --scope --user -p "Delegate=yes" kind create cluster
+systemd-run --scope --user -p "Delegate=yes" env KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 
 # ローカルレジストリ設定
 podman run -d -p 5000:5000 --name registry registry:2

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -107,7 +107,7 @@ podman generate systemd --name iot-collector --files
 systemctl --user enable container-iot-collector.service
 ```
 
-※ `podman generate systemd` は非推奨です。systemd連携は Quadlet（例: `.container`）を推奨します。
+※ `podman generate systemd` は非推奨（deprecated）です。今後の systemd 連携は Quadlet（例: `.container` ユニット）による管理を前提にしてください。
 
 **効果：**
 - メモリ使用量: 30%削減
@@ -470,13 +470,12 @@ kubectl run myapp --image=myapp:dev --image-pull-policy=Never
 
 ```bash
 # クラスター作成（rootless Podman provider; 公式推奨）
-export KIND_EXPERIMENTAL_PROVIDER=podman
-kind create cluster
+KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 
 # 一部環境では systemd-run が必要（公式docsの記載）
-systemd-run --scope --user kind create cluster
+systemd-run --scope --user env KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 # まだエラーが出る場合
-systemd-run --scope --user -p "Delegate=yes" kind create cluster
+systemd-run --scope --user -p "Delegate=yes" env KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 
 # ローカルレジストリ設定
 podman run -d -p 5000:5000 --name registry registry:2


### PR DESCRIPTION
Issue #176 対応。

- コマンド表記を推奨形へ統一: `podman kube play / podman kube generate / podman kube down`（旧表記はエイリアスとして注記）
- 「Kubernetes YAMLを直接実行」の表現を弱め、対応範囲（supported kinds/fields）は `podman-kube-play(1)` 参照に誘導
- 「CRI互換性」の誤解を招く表現を置換し、Podman≠CRI を明記（CRI-Oセクションとも整合）
- 「相違点とその理由」表のMarkdown整形（表としてレンダリングされるよう空行調整）
- kind（rootless Podman provider）の手順を公式推奨（`KIND_EXPERIMENTAL_PROVIDER=podman` / `systemd-run` 注記）に寄せ、旧手法（sockマウント）は標準手順ではない旨を注記
- 演習手順の矛盾を解消（kind推奨に合わせ、Minikube固定を回避）
- `podman generate systemd` の非推奨注記と Quadlet 推奨を追記

動作確認:
- `npm ci`
- `npm run build`

Closes #176
