### PR TITLE
第11章: 表示崩れ対策と誤解防止の追記 (#178)

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -50,7 +50,7 @@ PodmanはKubernetes YAMLとの相互運用（`podman kube generate` / `podman ku
 **相違点とその理由**
 
 | 特徴 | Podman | Kubernetes | なぜ違いが必要か |
-|------|--------|------------|-----------------|
+|---|---|---|---|
 | スケール | 単一ホスト | クラスター | 開発環境のシンプルさと本番のスケーラビリティの両立 |
 | オーケストレーション | なし | あり | ローカルでは不要な複雑性を排除 |
 | サービスディスカバリ | 基本的 | 高度 | 開発時は簡潔さを優先 |
@@ -59,6 +59,8 @@ PodmanはKubernetes YAMLとの相互運用（`podman kube generate` / `podman ku
 これらの違いは欠点ではなく、各環境の目的に最適化された設計の結果です。
 
 ## 実際のエンタープライズ運用事例
+
+※本節の事例・数値は理解を助けるためのモデルケース（例示）です。
 
 ### 事例1: 金融機関での段階的移行（A銀行）
 
@@ -196,6 +198,8 @@ podman pod ps
 podman kube down deployment.yaml
 ```
 
+※ `podman kube down` 実行後も、`podman kube play` が作成した volume は残ります。不要な場合は `--force` を使用するか、手動で volume を削除してください。
+
 **サポートされるリソースタイプ**
 - Pod
 - Deployment（Podとして実行）
@@ -279,6 +283,8 @@ podman kube generate mypod > pod.yaml
 # Serviceも含めて生成
 podman kube generate -s mypod > deployment.yaml
 ```
+
+※ `-s/--service` で Service 定義も生成できますが、`podman kube play` は Service を再現しません。生成した Service は実クラスタ適用用の雛形として扱ってください。
 
 **生成されるYAMLの例**
 ```yaml

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -48,7 +48,7 @@ PodmanはKubernetes YAMLとの相互運用（`podman kube generate` / `podman ku
 **相違点とその理由**
 
 | 特徴 | Podman | Kubernetes | なぜ違いが必要か |
-|------|--------|------------|-----------------|
+|---|---|---|---|
 | スケール | 単一ホスト | クラスター | 開発環境のシンプルさと本番のスケーラビリティの両立 |
 | オーケストレーション | なし | あり | ローカルでは不要な複雑性を排除 |
 | サービスディスカバリ | 基本的 | 高度 | 開発時は簡潔さを優先 |
@@ -57,6 +57,8 @@ PodmanはKubernetes YAMLとの相互運用（`podman kube generate` / `podman ku
 これらの違いは欠点ではなく、各環境の目的に最適化された設計の結果です。
 
 ## 実際のエンタープライズ運用事例
+
+※本節の事例・数値は理解を助けるためのモデルケース（例示）です。
 
 ### 事例1: 金融機関での段階的移行（A銀行）
 
@@ -194,6 +196,8 @@ podman pod ps
 podman kube down deployment.yaml
 ```
 
+※ `podman kube down` 実行後も、`podman kube play` が作成した volume は残ります。不要な場合は `--force` を使用するか、手動で volume を削除してください。
+
 **サポートされるリソースタイプ**
 - Pod
 - Deployment（Podとして実行）
@@ -277,6 +281,8 @@ podman kube generate mypod > pod.yaml
 # Serviceも含めて生成
 podman kube generate -s mypod > deployment.yaml
 ```
+
+※ `-s/--service` で Service 定義も生成できますが、`podman kube play` は Service を再現しません。生成した Service は実クラスタ適用用の雛形として扱ってください。
 
 **生成されるYAMLの例**
 ```yaml


### PR DESCRIPTION
Issue #178 対応。

- 「相違点とその理由」のテーブル区切り行をGFM形式（`|---|`）に調整し、表としてレンダリングされることを担保
- `podman kube down` 実行後も volume が残る点と、`--force`/手動削除の注意を追記
- `podman kube generate -s/--service` の Service 生成は「実クラスタ適用用の雛形」であり、`podman kube play` では再現しない旨を追記
- 「実際のエンタープライズ運用事例」はモデルケース（例示）である注記を追加

補足:
- 11.3.2 の YAML 例は現行で fenced code block（```yaml）になっているため、本PRでは追加の変更はありません。

動作確認:
- `npm run build`

Closes #178
