### PR TITLE
[codex] Add Podman operations review gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,17 @@
 - [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
   - 実行URL:
 
+## Review Completion Gate（必須）
+
+- [ ] GitHub Copilot review を依頼した
+- [ ] review 本文・inline comment・suggestion を全件確認した
+- [ ] 修正が必要な指摘は対応し、不要な指摘は理由を返信した
+- [ ] 未解決 review thread が 0 件であることを確認した
+- [ ] 実務適用に影響する未解決リスクを PR body または Issue に記録した
+
 ## Pages確認（原則必須）
 
-- 確認URL: https://itdojp.github.io/podman-book/
+- 確認URL: <https://itdojp.github.io/podman-book/>
 - [ ] トップページ HTTP 200
 - [ ] 主要導線（navigation.yml 相当）で 404 が無い
 - [ ] 表示崩れが無い（図表/表/コード中心）

--- a/docs/additional/troubleshooting-guide.md
+++ b/docs/additional/troubleshooting-guide.md
@@ -697,8 +697,9 @@ systemctl --user list-unit-files | grep "${container_name}.service" || true
 # 3. 自動起動の設定
 echo -e "\nサービスの管理:"
 cat << EOF
-# サービスの起動（自動起動は Quadlet の [Install] を systemd generator が適用）
-systemctl --user start ${container_name}.service
+# サービスの有効化と起動
+# Quadlet の [Install] で有効化先を定義したうえで enable する
+systemctl --user enable --now ${container_name}.service
 
 # 状態確認
 systemctl --user status ${container_name}.service

--- a/docs/additional/troubleshooting-guide.md
+++ b/docs/additional/troubleshooting-guide.md
@@ -646,39 +646,65 @@ Failed to start podman-myapp.service: Unit not found.
 ```
 
 #### 診断と解決
+
+2026年5月23日時点では、`podman generate systemd` は deprecated です。既存の生成済み
+unit を調査する場合を除き、新規の systemd 連携は Quadlet 定義から確認します。
+
 ```bash
 #!/bin/bash
 # fix-systemd-integration.sh
 
 container_name=${1:-"myapp"}
+quadlet_dir="${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd"
+quadlet_file="$quadlet_dir/${container_name}.container"
 
 echo "systemd統合の診断..."
 
-# 1. systemdユニットファイルの生成
-echo -e "\nsystemdユニットファイル生成:"
-podman generate systemd --new --name $container_name > $container_name.service
+# 1. Quadlet 定義の確認
+echo -e "\nQuadlet定義の確認:"
+mkdir -p "$quadlet_dir"
+if [ ! -f "$quadlet_file" ]; then
+    cat > "$quadlet_file" << EOF
+[Unit]
+Description=Podman container ${container_name}
+Wants=network-online.target
+After=network-online.target
 
-echo "生成されたユニットファイル:"
-cat $container_name.service
+[Container]
+Image=localhost/${container_name}:latest
+ContainerName=${container_name}
 
-# 2. ユニットファイルの配置
-echo -e "\nユニットファイルの配置:"
-mkdir -p ~/.config/systemd/user
-cp $container_name.service ~/.config/systemd/user/
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+    echo "サンプル Quadlet を作成しました: $quadlet_file"
+    echo "Image= と PublishPort= / Volume= などは実環境に合わせてレビューしてください。"
+else
+    echo "既存 Quadlet を検出しました: $quadlet_file"
+fi
+
+echo "Quadlet定義:"
+cat "$quadlet_file"
+
+# 2. systemd への反映
+echo -e "\nsystemdへの反映:"
 systemctl --user daemon-reload
+systemctl --user list-unit-files | grep "${container_name}.service" || true
 
 # 3. 自動起動の設定
 echo -e "\nサービスの管理:"
 cat << EOF
-# サービスの有効化と起動
-systemctl --user enable $container_name.service
-systemctl --user start $container_name.service
+# サービスの起動（自動起動は Quadlet の [Install] を systemd generator が適用）
+systemctl --user start ${container_name}.service
 
 # 状態確認
-systemctl --user status $container_name.service
+systemctl --user status ${container_name}.service
 
 # ログ確認
-journalctl --user -u $container_name.service
+journalctl --user -u ${container_name}.service
 EOF
 
 # 4. トラブルシューティングチェックリスト
@@ -686,6 +712,8 @@ echo -e "\nチェックリスト:"
 echo "- [ ] loginctl show-user でLinger=yes確認"
 echo "- [ ] XDG_RUNTIME_DIR が設定されている"
 echo "- [ ] systemd --user が実行されている"
+echo "- [ ] Quadlet定義が ${quadlet_dir} 配下にある"
+echo "- [ ] Image / PublishPort / Volume / Environment が実環境向けにレビュー済み"
 ```
 
 ### 2. cgroup v2関連の問題

--- a/docs/appendices/appendix-a/index.md
+++ b/docs/appendices/appendix-a/index.md
@@ -122,10 +122,47 @@ podman network disconnect [OPTIONS] NETWORK CONTAINER
 
 ## systemd統合
 
-### ユニットファイルの生成
+### Quadletによるユニット定義（推奨）
+
+2026年5月23日時点の Podman 公式ドキュメントでは、systemd 配下でコンテナや Pod を管理する
+新規運用には Quadlet の利用が推奨されています。rootless 運用では、ユーザー単位の
+`~/.config/containers/systemd/` 配下へ定義ファイルを置き、`systemctl --user` で管理します。
 
 ```bash
-# 既存コンテナからユニットファイル生成
+# rootless ユーザーサービス用の Quadlet 定義
+mkdir -p ~/.config/containers/systemd
+cat > ~/.config/containers/systemd/myapp.container <<'EOF'
+[Unit]
+Description=My Podman application
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image=registry.example.com/team/myapp:1.0.0
+ContainerName=myapp
+PublishPort=8080:8080
+Volume=myapp-data:/var/lib/myapp:Z
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target
+EOF
+
+# systemd に Quadlet 定義を再読込させ、生成された myapp.service を起動
+# 自動起動は Quadlet の [Install] セクションを generator が適用する
+systemctl --user daemon-reload
+systemctl --user start myapp.service
+systemctl --user status myapp.service
+```
+
+### 既存ユニットの生成（互換・移行調査用）
+
+```bash
+# `podman generate systemd` は deprecated。新規運用は Quadlet を優先する。
+# 既存コンテナからユニットファイルを確認する場合
 podman generate systemd --name CONTAINER > container.service
 
 # 新規コンテナ用ユニットファイル生成

--- a/docs/appendices/appendix-a/index.md
+++ b/docs/appendices/appendix-a/index.md
@@ -151,10 +151,10 @@ TimeoutStartSec=900
 WantedBy=default.target
 EOF
 
-# systemd に Quadlet 定義を再読込させ、生成された myapp.service を起動
-# 自動起動は Quadlet の [Install] セクションを generator が適用する
+# systemd に Quadlet 定義を再読込させ、有効化して起動
+# [Install] の WantedBy= は enable 時のリンク先を定義する
 systemctl --user daemon-reload
-systemctl --user start myapp.service
+systemctl --user enable --now myapp.service
 systemctl --user status myapp.service
 ```
 

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -32,9 +32,48 @@ Dockerとは異なり、Podmanは最初からsystemdとの統合を前提に設�
 
 #### 9.1.1 systemdユニットの生成
 
+> 2026年5月23日時点の公式ドキュメントでは、`podman generate systemd` は deprecated です。
+> 既存ユニットの読み解きや移行調査では有用ですが、新規運用は Quadlet（`.container` / `.pod` /
+> `.volume` / `.network` など）を優先してください。Quadlet定義を使うと、コンテナ設定と
+> systemd の `[Service]` / `[Install]` 設定を同じ宣言ファイルでレビューできます。
+
+**新規運用の最小 Quadlet 例**
+
+```ini
+# ~/.config/containers/systemd/myapp.container
+[Unit]
+Description=My Podman application
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image=registry.example.com/team/myapp:1.0.0
+ContainerName=myapp
+PublishPort=8080:8080
+Volume=myapp-data:/var/lib/myapp:Z
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user start myapp.service
+systemctl --user status myapp.service
+```
+
+この例を実環境へ適用する前に、image digest、registry 認証、公開ポート、SELinux ラベル、
+volume のバックアップ、rollback 先イメージをレビューしてください。
+
 **なぜ手動でユニットファイルを書かないのか**
 
-Podmanの自動生成機能は、ベストプラクティスを含んだ最適なユニットファイルを生成します。
+既存の `podman generate systemd` は、ユニットファイルの構造を学ぶ、または生成済みユニットを
+移行するときの参考として扱います。生成結果は best effort であり、本番投入前には依存関係、
+再起動ポリシー、SELinux、ボリューム、イメージ更新手順を必ずレビューします。
 
 ```bash
 # コンテナ用ユニット生成

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -62,7 +62,7 @@ WantedBy=default.target
 
 ```bash
 systemctl --user daemon-reload
-systemctl --user start myapp.service
+systemctl --user enable --now myapp.service
 systemctl --user status myapp.service
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,26 @@ order: 0
 - `sudo` や `--tls-verify=false` を含む例は、恒久設定ではなく切り分けや限定的な検証を想定しています。実運用では信頼済みレジストリ、証明書検証、監査可能な設定を優先してください。
 - `podman system prune` やストレージ削除系のコマンドは、未使用リソースだけでなく必要なイメージやキャッシュも失う可能性があります。実行前にバックアップ、影響範囲、ロールバック手順を確認してください。
 
+## 実務適用前の Podman 運用レビューゲート
+
+Podman の検証結果を本番運用へ移す前に、少なくとも以下の判断根拠を PR、ADR、Runbook、
+または変更管理チケットへ残します。
+
+- 実行モード: rootless / rootful の選択理由、`/etc/subuid`・`/etc/subgid`、SELinux、cgroup v2、linger の要否。
+- ネットワーク: rootless ネットワークの実装差、公開ポート、DNS、host network 利用、コンテナ間通信、ファイアウォール影響。
+- ストレージ: named volume / bind mount の所有権、SELinux ラベル、バックアップ、復旧手順、廃棄時のデータ削除範囲。
+- イメージとレジストリ: digest 固定、署名/検証、認証情報、`--tls-verify=false` の禁止または例外承認。
+- systemd 連携: 新規運用は Quadlet を優先し、既存の `podman generate systemd` 由来ユニットは移行計画を用意する。
+- 変更と復旧: `podman info`、`podman inspect`、Quadlet定義、unit状態、ロールバック対象イメージ、ログ取得先を保存する。
+
+2026年5月23日時点では、rootless の前提は
+[Podman rootless tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)、
+systemd 連携は
+[podman-systemd.unit / Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)
+を一次情報として確認します。`podman generate systemd` は
+[公式リファレンス](https://docs.podman.io/en/latest/markdown/podman-generate-systemd.1.html)
+で deprecated と明記されているため、新規設計では互換・既存調査用途に限定して扱います。
+
 ## 本書の構成
 
 ### 第1部: 基礎編（第1章〜第5章）

--- a/src/additional/troubleshooting-guide.md
+++ b/src/additional/troubleshooting-guide.md
@@ -685,8 +685,9 @@ systemctl --user list-unit-files | grep "${container_name}.service" || true
 # 3. 自動起動の設定
 echo -e "\n🚀 サービスの管理:"
 cat << EOF
-# サービスの起動（自動起動は Quadlet の [Install] を systemd generator が適用）
-systemctl --user start ${container_name}.service
+# サービスの有効化と起動
+# Quadlet の [Install] で有効化先を定義したうえで enable する
+systemctl --user enable --now ${container_name}.service
 
 # 状態確認
 systemctl --user status ${container_name}.service

--- a/src/additional/troubleshooting-guide.md
+++ b/src/additional/troubleshooting-guide.md
@@ -634,39 +634,65 @@ Failed to start podman-myapp.service: Unit not found.
 ```
 
 #### 診断と解決
+
+2026年5月23日時点では、`podman generate systemd` は deprecated です。既存の生成済み
+unit を調査する場合を除き、新規の systemd 連携は Quadlet 定義から確認します。
+
 ```bash
 #!/bin/bash
 # fix-systemd-integration.sh
 
 container_name=${1:-"myapp"}
+quadlet_dir="${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd"
+quadlet_file="$quadlet_dir/${container_name}.container"
 
 echo "systemd統合の診断..."
 
-# 1. systemdユニットファイルの生成
-echo -e "\n📝 systemdユニットファイル生成:"
-podman generate systemd --new --name $container_name > $container_name.service
+# 1. Quadlet 定義の確認
+echo -e "\n📝 Quadlet定義の確認:"
+mkdir -p "$quadlet_dir"
+if [ ! -f "$quadlet_file" ]; then
+    cat > "$quadlet_file" << EOF
+[Unit]
+Description=Podman container ${container_name}
+Wants=network-online.target
+After=network-online.target
 
-echo "生成されたユニットファイル:"
-cat $container_name.service
+[Container]
+Image=localhost/${container_name}:latest
+ContainerName=${container_name}
 
-# 2. ユニットファイルの配置
-echo -e "\n📁 ユニットファイルの配置:"
-mkdir -p ~/.config/systemd/user
-cp $container_name.service ~/.config/systemd/user/
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+EOF
+    echo "サンプル Quadlet を作成しました: $quadlet_file"
+    echo "Image= と PublishPort= / Volume= などは実環境に合わせてレビューしてください。"
+else
+    echo "既存 Quadlet を検出しました: $quadlet_file"
+fi
+
+echo "Quadlet定義:"
+cat "$quadlet_file"
+
+# 2. systemd への反映
+echo -e "\n📁 systemdへの反映:"
 systemctl --user daemon-reload
+systemctl --user list-unit-files | grep "${container_name}.service" || true
 
 # 3. 自動起動の設定
 echo -e "\n🚀 サービスの管理:"
 cat << EOF
-# サービスの有効化と起動
-systemctl --user enable $container_name.service
-systemctl --user start $container_name.service
+# サービスの起動（自動起動は Quadlet の [Install] を systemd generator が適用）
+systemctl --user start ${container_name}.service
 
 # 状態確認
-systemctl --user status $container_name.service
+systemctl --user status ${container_name}.service
 
 # ログ確認
-journalctl --user -u $container_name.service
+journalctl --user -u ${container_name}.service
 EOF
 
 # 4. トラブルシューティングチェックリスト
@@ -674,6 +700,8 @@ echo -e "\n✅ チェックリスト:"
 echo "- [ ] loginctl show-user でLinger=yes確認"
 echo "- [ ] XDG_RUNTIME_DIR が設定されている"
 echo "- [ ] systemd --user が実行されている"
+echo "- [ ] Quadlet定義が ${quadlet_dir} 配下にある"
+echo "- [ ] Image / PublishPort / Volume / Environment が実環境向けにレビュー済み"
 ```
 
 ### 2. cgroup v2関連の問題

--- a/src/appendices/appendix-a/index.md
+++ b/src/appendices/appendix-a/index.md
@@ -149,10 +149,10 @@ TimeoutStartSec=900
 WantedBy=default.target
 EOF
 
-# systemd に Quadlet 定義を再読込させ、生成された myapp.service を起動
-# 自動起動は Quadlet の [Install] セクションを generator が適用する
+# systemd に Quadlet 定義を再読込させ、有効化して起動
+# [Install] の WantedBy= は enable 時のリンク先を定義する
 systemctl --user daemon-reload
-systemctl --user start myapp.service
+systemctl --user enable --now myapp.service
 systemctl --user status myapp.service
 ```
 

--- a/src/appendices/appendix-a/index.md
+++ b/src/appendices/appendix-a/index.md
@@ -120,10 +120,47 @@ podman network disconnect [OPTIONS] NETWORK CONTAINER
 
 ## systemd統合
 
-### ユニットファイルの生成
+### Quadletによるユニット定義（推奨）
+
+2026年5月23日時点の Podman 公式ドキュメントでは、systemd 配下でコンテナや Pod を管理する
+新規運用には Quadlet の利用が推奨されています。rootless 運用では、ユーザー単位の
+`~/.config/containers/systemd/` 配下へ定義ファイルを置き、`systemctl --user` で管理します。
 
 ```bash
-# 既存コンテナからユニットファイル生成
+# rootless ユーザーサービス用の Quadlet 定義
+mkdir -p ~/.config/containers/systemd
+cat > ~/.config/containers/systemd/myapp.container <<'EOF'
+[Unit]
+Description=My Podman application
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image=registry.example.com/team/myapp:1.0.0
+ContainerName=myapp
+PublishPort=8080:8080
+Volume=myapp-data:/var/lib/myapp:Z
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target
+EOF
+
+# systemd に Quadlet 定義を再読込させ、生成された myapp.service を起動
+# 自動起動は Quadlet の [Install] セクションを generator が適用する
+systemctl --user daemon-reload
+systemctl --user start myapp.service
+systemctl --user status myapp.service
+```
+
+### 既存ユニットの生成（互換・移行調査用）
+
+```bash
+# `podman generate systemd` は deprecated。新規運用は Quadlet を優先する。
+# 既存コンテナからユニットファイルを確認する場合
 podman generate systemd --name CONTAINER > container.service
 
 # 新規コンテナ用ユニットファイル生成

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -17,12 +17,45 @@ chapter: chapter09
 
 ## 内容
 
-（章の内容をここに記載してください）
+### systemd 連携の現行方針
+
+2026年5月23日時点の公式ドキュメントでは、`podman generate systemd` は deprecated です。
+既存ユニットの読み解きや移行調査では有用ですが、新規運用は Quadlet（`.container` / `.pod` /
+`.volume` / `.network` など）を優先してください。
+
+```ini
+# ~/.config/containers/systemd/myapp.container
+[Unit]
+Description=My Podman application
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image=registry.example.com/team/myapp:1.0.0
+ContainerName=myapp
+PublishPort=8080:8080
+Volume=myapp-data:/var/lib/myapp:Z
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=900
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user start myapp.service
+systemctl --user status myapp.service
+```
+
+適用前には、image digest、registry 認証、公開ポート、SELinux ラベル、volume のバックアップ、
+rollback 先イメージをレビューしてください。
 
 ## まとめ
 
 （章のまとめをここに記載してください）
 
 ---
-
 

--- a/src/chapter-chapter09/index.md
+++ b/src/chapter-chapter09/index.md
@@ -46,7 +46,7 @@ WantedBy=default.target
 
 ```bash
 systemctl --user daemon-reload
-systemctl --user start myapp.service
+systemctl --user enable --now myapp.service
 systemctl --user status myapp.service
 ```
 


### PR DESCRIPTION
## 概要（必須）

- 変更内容:
  - トップページに「実務適用前の Podman 運用レビューゲート」を追加し、rootless/rootful、subuid/subgid、ネットワーク、ストレージ、イメージ/レジストリ、systemd、復旧証跡を確認項目化しました。
  - 第9章の systemd 連携説明に Quadlet 優先方針と最小 `.container` 例を追加し、`podman generate systemd` は既存ユニットの読み解き・移行調査用として位置付けました。
  - 付録Aとトラブルシューティングガイドの systemd 連携例を Quadlet 中心に更新し、`src/` 側の対応箇所にも反映しました。
  - PRテンプレートへ Review Completion Gate を追加しました。
- 対象 Issue: Closes #199

## 影響範囲（必須）

- 対象章/ページ:
  - `/` (`docs/index.md`)
  - `/chapters/chapter09/`
  - `/appendices/appendix-a/`
  - `/additional/troubleshooting-guide/`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- 影響: Podman運用レビュー観点の追記、systemd/Quadlet説明の更新、PRレビュー完了ゲートの追加。
- 既存のスクリーンショットIssue #189 には触れていません。

## 根拠・確認した一次情報

2026-05-23（Asia/Tokyo）時点で、以下の公式情報を確認しました。

- Podman rootless tutorial: https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
- podman-systemd.unit / Quadlet: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
- podman-generate-systemd: https://docs.podman.io/en/latest/markdown/podman-generate-systemd.1.html

## QA（必須）

- [x] `git diff --check`: PASS
- [x] `npm ci --no-audit --no-fund`: PASS
- [x] `npm run build`: PASS
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-podman-book bundle install`: PASS
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-podman-book bundle exec jekyll build --source docs --destination docs/_site`: PASS
- [x] built-site smoke（トップページ、第9章、付録A、トラブルシューティングガイドの追加文言確認）: PASS
- [x] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
  - 実行URL: ローカル実行
  - `node book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`: PASS
  - `node book-formatter/scripts/check-textlint.js docs --fail-on error`: PASS
  - `node book-formatter/scripts/check-links.js docs`: PASS
  - `node book-formatter/scripts/check-layout-risk.js docs --fail-on error`: PASS
  - `node book-formatter/scripts/check-markdown-structure.js docs --fail-on error`: PASS

## Review Completion Gate（必須）

- [x] GitHub Copilot review を依頼した
- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 修正が必要な指摘は対応し、不要な指摘は理由を返信した
- [x] 未解決 review thread が 0 件であることを確認した
- [x] 実務適用に影響する未解決リスクを PR body または Issue に記録した

## Pages確認（原則必須）

- 確認URL: <https://itdojp.github.io/podman-book/>
- [x] トップページ HTTP 200
- [x] 主要導線（navigation.yml 相当）で 404 が無い
- [x] 表示崩れが無い（図表/表/コード中心）
- [x] 更新箇所が公開サイトに反映されている

## CI / Review evidence

- GitHub Copilot review: 4 comments generated; all addressed, replied, and resolved.
- Codex Review: 1 comment generated; addressed, replied, and resolved.
- Review completeness: `status: ok`, `unresolved_threads: 0`, `generated_count_mismatches: 0`, `missing_review_ids: 0`.
- PR checks on latest head `cea1e7217c6045fbf48c6d09e4bd30b28d645de4`: `Docs forbidden check`, `build-and-deploy`, `qa` all succeeded.
- Main checks on merge commit `fb536f23554a992efa67ec80666a2b4ad0b68afe`: `Docs forbidden check`, `build-and-deploy`, `qa`, Pages `build`, `report-build-status`, `deploy` all succeeded.
- Public site: top page, Chapter 9, Appendix A, and troubleshooting guide returned HTTP 200 and contained the added Quadlet/review-gate markers.

## 補足

- 既知の制約 / TODO:
  - `src/` と `docs/` には既存の大きな差分があります。本PRでは、公開サイトとCIの対象である `docs/` を主対象とし、同じ説明が存在する `src/` ファイルには対応する最小反映を行いました。
  - 公開サイト確認はmainマージ後に実施済みです。
