### PR TITLE
Add podman metadata consistency gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -21,6 +21,19 @@ jobs:
       - name: Checkout book
         uses: actions/checkout@v6
 
+      - name: Setup Node.js for metadata check
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install book dependencies
+        run: npm ci
+
+      - name: Metadata consistency check
+        run: npm run check:metadata
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
         
     - name: Install dependencies
       run: npm ci
+
+    - name: Metadata consistency check
+      run: npm run check:metadata
         
     - name: Build book
       run: npm run build

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 
 ```bash
 npm ci
-npm run check:metadata
 npm test
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@
 - リポジトリ内: `docs/index.md`
 - GitHub Pages を有効化している場合: `https://itdojp.github.io/podman-book/`
 
+## ローカル品質ゲート
+
+公開メタデータ、ナビゲーション、必須アセットのずれを防ぐため、PR前に次のチェックを実行してください。
+
+```bash
+npm ci
+npm run check:metadata
+npm test
+```
+
+`check:metadata` は `book-config.json`、`package.json`、`package-lock.json`、Jekyll設定、トップページfront matter、`docs/_data/navigation.yml`、設定済みページ、必須公開アセットの整合を検証します。
+
 ## フィードバック
 
 - Issue: `https://github.com/itdojp/podman-book/issues`

--- a/book-config.json
+++ b/book-config.json
@@ -15,97 +15,113 @@
         "id": "introduction",
         "title": "はじめに",
         "description": "Podman完全ガイドの概要と読み進め方",
-        "order": 1
+        "order": 1,
+        "path": "/introduction/"
       },
       {
         "id": "chapter01",
         "title": "第1章：コンテナ技術の基礎",
         "description": "Linux名前空間とcgroupsによるプロセス分離の実装",
-        "order": 2
+        "order": 2,
+        "path": "/chapters/chapter01/"
       },
       {
         "id": "chapter02",
         "title": "第2章：Podmanのインストールと初期設定",
         "description": "各OS対応のインストール方法と基本設定",
-        "order": 3
+        "order": 3,
+        "path": "/chapters/chapter02/"
       },
       {
         "id": "chapter03",
         "title": "第3章：基本的なコンテナ操作",
         "description": "コンテナの作成、実行、管理の基本コマンド",
-        "order": 4
+        "order": 4,
+        "path": "/chapters/chapter03/"
       },
       {
         "id": "chapter04",
         "title": "第4章：イメージの管理と作成",
         "description": "イメージのビルド、プッシュ、プルの実践",
-        "order": 5
+        "order": 5,
+        "path": "/chapters/chapter04/"
       },
       {
         "id": "chapter05",
         "title": "第5章：ストレージとボリューム管理",
         "description": "永続化ストレージとボリューム操作",
-        "order": 6
+        "order": 6,
+        "path": "/chapters/chapter05/"
       },
       {
         "id": "chapter06",
         "title": "第6章：ネットワーキングとポート管理",
         "description": "コンテナネットワークの設定と管理",
-        "order": 7
+        "order": 7,
+        "path": "/chapters/chapter06/"
       },
       {
         "id": "chapter07",
         "title": "第7章：Pod機能と複数コンテナ管理",
         "description": "Kubernetes互換のPod機能活用",
-        "order": 8
+        "order": 8,
+        "path": "/chapters/chapter07/"
       },
       {
         "id": "chapter08",
         "title": "第8章：Dockerfileの作成と最適化",
         "description": "効率的なDockerfileの作成技法",
-        "order": 9
+        "order": 9,
+        "path": "/chapters/chapter08/"
       },
       {
         "id": "chapter09",
         "title": "第9章：レジストリとイメージ配布",
         "description": "イメージレジストリの構築と管理",
-        "order": 10
+        "order": 10,
+        "path": "/chapters/chapter09/"
       },
       {
         "id": "chapter10",
         "title": "第10章：CI/CDパイプラインの実践",
         "description": "Podmanを使ったコンテナCI/CDの設計と実装",
-        "order": 11
+        "order": 11,
+        "path": "/chapters/chapter10/"
       },
       {
         "id": "chapter11",
         "title": "第11章：Kubernetesとの統合",
         "description": "K8s環境でのPodman活用",
-        "order": 12
+        "order": 12,
+        "path": "/chapters/chapter11/"
       },
       {
         "id": "chapter12",
         "title": "第12章：パフォーマンスチューニング",
         "description": "Podmanコンテナの性能計測と最適化手法",
-        "order": 13
+        "order": 13,
+        "path": "/chapters/chapter12/"
       },
       {
         "id": "chapter13",
         "title": "第13章：マイクロサービスアーキテクチャ",
         "description": "マイクロサービス構成とサービス間連携の実践",
-        "order": 14
+        "order": 14,
+        "path": "/chapters/chapter13/"
       },
       {
         "id": "chapter14",
         "title": "第14章：エンタープライズ環境での活用",
         "description": "エンタープライズ要件を満たす運用設計とセキュリティ",
-        "order": 15
+        "order": 15,
+        "path": "/chapters/chapter14/"
       },
       {
         "id": "chapter15",
         "title": "第15章：トラブルシューティング完全ガイド",
         "description": "障害解析を体系化する診断フレームワーク",
-        "order": 16
+        "order": 16,
+        "path": "/chapters/chapter15/"
       }
     ],
     "appendices": [
@@ -113,26 +129,30 @@
         "id": "appendix-a",
         "title": "付録A：コマンドリファレンス",
         "description": "Podmanコマンドの完全リファレンス",
-        "order": 17
+        "order": 17,
+        "path": "/appendices/appendix-a/"
       },
       {
         "id": "appendix-b",
         "title": "付録B：トラブルシューティングガイド",
         "description": "よくある問題と解決方法",
-        "order": 18
+        "order": 18,
+        "path": "/appendices/appendix-b/"
       },
       {
         "id": "appendix-c",
         "title": "付録C：リソース集",
         "description": "参考資料とリンク集",
-        "order": 19
+        "order": 19,
+        "path": "/appendices/appendix-c/"
       }
     ],
     "afterword": {
       "id": "afterword",
       "title": "あとがき",
       "description": "書籍のまとめと今後の展望",
-      "order": 20
+      "order": 20,
+      "path": "/afterword/"
     }
   },
   "ux": {
@@ -151,5 +171,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:00:48.959Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/podman-book/"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,10 @@
 ---
 layout: book
 title: "Podman完全ガイド"
+description: "コンテナ技術の理論と実践 - エンタープライズ環境でのPodman活用法"
+author: "株式会社アイティードゥ"
+version: "1.0.0"
+permalink: /
 order: 0
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "deploy-setup": "gh-pages-clean",
     "validate-deploy": "node scripts/validate-github-pages.js",
     "pages-status": "node scripts/check-pages-status.js",
-    "dev": "npm run build && npm run serve"
+    "dev": "npm run build && npm run serve",
+    "check:metadata": "node scripts/check-metadata-consistency.js",
+    "test": "npm run check:metadata && npm run build"
   },
   "devDependencies": {
     "gh-pages": "^6.0.0"
@@ -20,5 +22,8 @@
     "type": "git",
     "url": "https://github.com/itdojp/podman-book.git"
   },
-  "homepage": "https://itdojp.github.io/podman-book"
+  "homepage": "https://itdojp.github.io/podman-book/",
+  "bugs": {
+    "url": "https://github.com/itdojp/podman-book/issues"
+  }
 }

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/* Validate publication metadata and configured routes for the Podman book. */
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const docsRoot = path.join(repoRoot, 'docs');
+const expectedRepo = 'itdojp/podman-book';
+const expectedRepoUrl = `https://github.com/${expectedRepo}`;
+const expectedHomepage = 'https://itdojp.github.io/podman-book/';
+const expectedOrigin = 'https://itdojp.github.io';
+const expectedBaseurl = '/podman-book';
+const requiredAssets = [
+  'assets/css/main.css',
+  'assets/css/search.css',
+  'assets/css/syntax-highlighting.css',
+  'assets/js/theme.js',
+  'assets/js/search.js',
+  'assets/js/code-copy-lightweight.js',
+];
+
+const errors = [];
+
+function readJson(rel) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, rel), 'utf8'));
+}
+
+function parseScalar(value) {
+  const trimmed = String(value || '').trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseSimpleYaml(file) {
+  const out = {};
+  if (!fs.existsSync(file)) return out;
+  for (const line of fs.readFileSync(file, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || /^\s/.test(line) || trimmed.startsWith('-')) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx < 0) continue;
+    const key = trimmed.slice(0, idx).trim();
+    const value = trimmed.slice(idx + 1).trim();
+    if (value) out[key] = parseScalar(value);
+  }
+  return out;
+}
+
+function parseFrontMatter(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  if (!text.startsWith('---\n')) return {};
+  const end = text.indexOf('\n---\n', 4);
+  if (end < 0) return {};
+  const out = {};
+  for (const line of text.slice(4, end).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx < 0) continue;
+    out[trimmed.slice(0, idx).trim()] = parseScalar(trimmed.slice(idx + 1));
+  }
+  return out;
+}
+
+function parseNavigation(file) {
+  const entries = [];
+  let current = null;
+  const flush = () => {
+    if (current?.fields.title && current?.fields.path) {
+      entries.push({
+        title: current.fields.title,
+        path: current.fields.path,
+        titleLine: current.lines.title,
+        pathLine: current.lines.path,
+      });
+    }
+    current = null;
+  };
+  const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    const lineNo = idx + 1;
+    if (!line.trim() || line.trim().startsWith('#')) return;
+    const indent = line.match(/^ */)[0].length;
+    const trimmed = line.trim();
+    const itemMatch = trimmed.match(/^-\s+(title|path):\s*(.+)$/);
+    if (itemMatch) {
+      flush();
+      current = { indent, fields: { [itemMatch[1]]: parseScalar(itemMatch[2]) }, lines: { [itemMatch[1]]: lineNo } };
+      return;
+    }
+    if (trimmed.startsWith('- ')) {
+      flush();
+      return;
+    }
+    const fieldMatch = trimmed.match(/^(title|path):\s*(.+)$/);
+    if (fieldMatch && current && indent > current.indent) {
+      current.fields[fieldMatch[1]] = parseScalar(fieldMatch[2]);
+      current.lines[fieldMatch[1]] = lineNo;
+    }
+  });
+  flush();
+  return entries;
+}
+
+function normalizeRepoUrl(url) {
+  return String(url || '').replace(/\/$/, '').replace(/\.git$/, '');
+}
+
+function expectEqual(label, actual, expected) {
+  if (actual !== expected) errors.push(`${label} mismatch: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function isMalformedPath(value) {
+  return /[\0\r\n\\]/.test(value);
+}
+
+function candidatesForPublicPath(publicPath) {
+  if (typeof publicPath !== 'string' || !publicPath.trim()) {
+    errors.push('configured path is missing');
+    return [];
+  }
+  const value = publicPath.trim();
+  if (/^(https?:|mailto:)/.test(value)) return [];
+  if (!value.startsWith('/')) {
+    errors.push(`configured path must start with '/': ${value}`);
+    return [];
+  }
+  if (value.includes('?') || value.includes('#') || isMalformedPath(value)) {
+    errors.push(`configured path is malformed: ${JSON.stringify(value)}`);
+    return [];
+  }
+  const parts = value.split('/').filter(Boolean);
+  if (parts.includes('..')) {
+    errors.push(`configured path must not contain '..': ${value}`);
+    return [];
+  }
+  if (value === '/') return [path.join(docsRoot, 'index.md')];
+  const rel = value.replace(/^\//, '').replace(/\/$/, '');
+  if (/\.(md|html?|pdf|txt)$/i.test(rel)) return [path.join(docsRoot, rel)];
+  return [path.join(docsRoot, `${rel}.md`), path.join(docsRoot, rel, 'index.md')];
+}
+
+function existingCandidate(candidates, label) {
+  for (const candidate of candidates) {
+    let resolved;
+    try {
+      resolved = fs.realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    const rel = path.relative(fs.realpathSync(docsRoot), resolved);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      errors.push(`${label} target escapes docs tree: ${candidate}`);
+      return null;
+    }
+    const stat = fs.statSync(resolved);
+    if (stat.isFile() && stat.size > 0) return resolved;
+  }
+  if (candidates.length) {
+    errors.push(`${label} target does not exist in docs: ${candidates.map((c) => path.relative(repoRoot, c)).join(', ')}`);
+  }
+  return null;
+}
+
+function flattenStructure(structure) {
+  const entries = [];
+  for (const section of ['chapters', 'appendices']) {
+    for (const item of structure?.[section] || []) entries.push({ section, ...item });
+  }
+  if (structure?.afterword) entries.push({ section: 'afterword', ...structure.afterword });
+  return entries;
+}
+
+const book = readJson('book-config.json');
+const pkg = readJson('package.json');
+const lock = readJson('package-lock.json');
+const rootConfig = parseSimpleYaml(path.join(repoRoot, '_config.yml'));
+const docsConfig = parseSimpleYaml(path.join(docsRoot, '_config.yml'));
+const indexFrontMatter = parseFrontMatter(path.join(docsRoot, 'index.md'));
+const navEntries = parseNavigation(path.join(docsRoot, '_data', 'navigation.yml'));
+const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+
+expectEqual('package.json name', pkg.name, 'podman-book');
+expectEqual('package.json version', pkg.version, book.version);
+expectEqual('package.json description', pkg.description, book.description);
+expectEqual('package.json author', pkg.author, book.author);
+expectEqual('package.json license', pkg.license, book.license);
+expectEqual('package.json repository.url', normalizeRepoUrl(pkg.repository?.url), expectedRepoUrl);
+expectEqual('package.json homepage', pkg.homepage, expectedHomepage);
+expectEqual('package.json bugs.url', pkg.bugs?.url, `${expectedRepoUrl}/issues`);
+expectEqual('package-lock root name', lock.packages?.['']?.name, pkg.name);
+expectEqual('package-lock root version', lock.packages?.['']?.version, pkg.version);
+expectEqual('package-lock root license', lock.packages?.['']?.license, pkg.license);
+
+expectEqual('book-config repository.url', normalizeRepoUrl(book.repository?.url), expectedRepoUrl);
+expectEqual('book-config repository.branch', book.repository?.branch, 'main');
+expectEqual('book-config homepage', book.homepage, expectedHomepage);
+
+for (const [label, cfg] of [['root _config.yml', rootConfig], ['docs/_config.yml', docsConfig]]) {
+  expectEqual(`${label} title`, cfg.title, book.title);
+  expectEqual(`${label} description`, cfg.description, book.description);
+  expectEqual(`${label} author`, cfg.author, book.author);
+  expectEqual(`${label} version`, cfg.version, book.version);
+  expectEqual(`${label} lang`, cfg.lang, book.language);
+  expectEqual(`${label} repository`, cfg.repository, expectedRepo);
+}
+expectEqual('docs/_config.yml url', docsConfig.url, expectedOrigin);
+expectEqual('docs/_config.yml baseurl', docsConfig.baseurl, expectedBaseurl);
+
+for (const [key, expected] of Object.entries({
+  title: book.title,
+  description: book.description,
+  author: book.author,
+  version: book.version,
+  permalink: '/',
+})) {
+  expectEqual(`docs/index.md front matter ${key}`, indexFrontMatter[key], expected);
+}
+
+if (!readme.includes(expectedHomepage)) errors.push(`README.md must include canonical Pages URL: ${expectedHomepage}`);
+if (!readme.includes(book.title)) errors.push('README.md must include canonical book title');
+
+const structureEntries = flattenStructure(book.structure);
+const seenIds = new Map();
+const seenPaths = new Map();
+structureEntries.forEach((item) => {
+  if (!item.id) errors.push(`book-config ${item.section} entry is missing id`);
+  if (!item.path) errors.push(`book-config ${item.id || item.title} is missing path`);
+  if (item.id) {
+    if (seenIds.has(item.id)) errors.push(`duplicated book-config id: ${item.id}`);
+    seenIds.set(item.id, true);
+  }
+  if (item.path) {
+    if (seenPaths.has(item.path)) errors.push(`duplicated book-config path: ${item.path}`);
+    seenPaths.set(item.path, true);
+    existingCandidate(candidatesForPublicPath(item.path), `book-config ${item.id}`);
+  }
+});
+
+const navPathSet = new Set();
+navEntries.forEach((entry) => {
+  if (navPathSet.has(entry.path)) errors.push(`duplicated navigation path: ${entry.path}`);
+  navPathSet.add(entry.path);
+  existingCandidate(candidatesForPublicPath(entry.path), `navigation line ${entry.pathLine}`);
+});
+for (const item of structureEntries) {
+  if (item.path && item.section !== 'afterword' && !navPathSet.has(item.path)) {
+    errors.push(`book-config path is not present in docs navigation: ${item.path}`);
+  }
+}
+
+for (const asset of requiredAssets) {
+  const assetPath = path.join(docsRoot, asset);
+  if (!fs.existsSync(assetPath) || !fs.statSync(assetPath).isFile() || fs.statSync(assetPath).size === 0) {
+    errors.push(`required public asset is missing or empty: docs/${asset}`);
+  }
+}
+
+if (errors.length) {
+  console.error('Metadata consistency check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(`✅ Metadata consistency check passed (${structureEntries.length} configured pages, ${navEntries.length} navigation paths, ${requiredAssets.length} assets).`);

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -116,6 +116,16 @@ function isMalformedPath(value) {
   return /[\0\r\n\\]/.test(value);
 }
 
+function decodeConfiguredPath(value) {
+  if (/%(?![0-9A-Fa-f]{2})/.test(value)) return null;
+  if (/%(?:2f|5c)/i.test(value)) return null;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
 function candidatesForPublicPath(publicPath) {
   if (typeof publicPath !== 'string' || !publicPath.trim()) {
     errors.push('configured path is missing');
@@ -127,17 +137,22 @@ function candidatesForPublicPath(publicPath) {
     errors.push(`configured path must start with '/': ${value}`);
     return [];
   }
-  if (value.includes('?') || value.includes('#') || isMalformedPath(value)) {
+  const decoded = decodeConfiguredPath(value);
+  if (!decoded) {
     errors.push(`configured path is malformed: ${JSON.stringify(value)}`);
     return [];
   }
-  const parts = value.split('/').filter(Boolean);
+  if (decoded.includes('?') || decoded.includes('#') || isMalformedPath(decoded)) {
+    errors.push(`configured path is malformed: ${JSON.stringify(value)}`);
+    return [];
+  }
+  const parts = decoded.split('/').filter(Boolean);
   if (parts.includes('..')) {
     errors.push(`configured path must not contain '..': ${value}`);
     return [];
   }
-  if (value === '/') return [path.join(docsRoot, 'index.md')];
-  const rel = value.replace(/^\//, '').replace(/\/$/, '');
+  if (decoded === '/') return [path.join(docsRoot, 'index.md')];
+  const rel = decoded.replace(/^\//, '').replace(/\/$/, '');
   if (/\.(md|html?|pdf|txt)$/i.test(rel)) return [path.join(docsRoot, rel)];
   return [path.join(docsRoot, `${rel}.md`), path.join(docsRoot, rel, 'index.md')];
 }


### PR DESCRIPTION
## Summary
- Add `scripts/check-metadata-consistency.js` to validate canonical metadata, configured routes, navigation targets, and required public assets.
- Add canonical Pages `homepage`, configured `path` values in `book-config.json`, and explicit top-page description/author/version/permalink front matter.
- Add `check:metadata` and `test` scripts; wire metadata validation into the build and Book QA workflows.
- Document the local quality gate in README.

## Validation
- `node --check scripts/check-metadata-consistency.js`
- `npm ci`
- `npm run check:metadata`
- `npm test`
- `npm audit --omit=dev --omit=optional`
- `git diff --check`
- Bundler-backed Jekyll build and smoke for `/`, `/chapters/chapter15/`, `/appendices/appendix-c/`
- CI-pinned book-formatter checks: Unicode, textlint/PRH, internal links, layout risk, markdown structure
- Metadata fixtures for homepage drift, missing configured path, malformed navigation query, and symlink escape

## Notes
- Open issue #189 is screenshot acquisition/insertion follow-up work and was not selected for this metadata/QA slice because it requires concrete screenshot assets.
- `npm ci` still reports an existing dev dependency audit finding; production/non-optional audit passes.