### PR TITLE
chore: add npm security QA gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install book dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm run check:security
+
       - name: Metadata consistency check
         run: npm run check:metadata
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,13 @@ jobs:
       with:
         node-version: '20'
         cache: 'npm'
+        cache-dependency-path: package-lock.json
         
     - name: Install dependencies
       run: npm ci
+
+    - name: Security audit
+      run: npm run check:security
 
     - name: Metadata consistency check
       run: npm run check:metadata

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,15 @@ pids/
 # Documentation build
 docs/_build/
 docs/.vuepress/dist/
+_site/
+docs/_site/
+.jekyll-cache/
+docs/.jekyll-cache/
+.jekyll-metadata
+docs/.jekyll-metadata
+.bundle/
+vendor/bundle/
+Gemfile.lock
 
 # Misc
 .sass-cache/

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@
 
 ```bash
 npm ci
+npm run check:security
 npm test
 ```
 
+`check:security` は `npm audit` を実行し、公開・デプロイ関連の npm 依存関係に既知脆弱性がないことを確認します。
 `check:metadata` は `book-config.json`、`package.json`、`package-lock.json`、Jekyll設定、トップページfront matter、`docs/_data/navigation.yml`、設定済みページ、必須公開アセットの整合を検証します。
 
 ## フィードバック

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "CC-BY-NC-SA-4.0",
       "devDependencies": {
-        "gh-pages": "^6.0.0"
+        "gh-pages": "^6.3.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "pages-status": "node scripts/check-pages-status.js",
     "dev": "npm run build && npm run serve",
     "check:metadata": "node scripts/check-metadata-consistency.js",
+    "check:security": "npm audit",
     "test": "npm run check:metadata && npm run build"
   },
   "devDependencies": {
-    "gh-pages": "^6.0.0"
+    "gh-pages": "^6.3.0"
   },
   "repository": {
     "type": "git",

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -22,7 +22,19 @@ const requiredAssets = [
 const errors = [];
 
 function readJson(rel) {
-  return JSON.parse(fs.readFileSync(path.join(repoRoot, rel), 'utf8'));
+  const file = path.join(repoRoot, rel);
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      errors.push(`${rel} is missing`);
+    } else if (error instanceof SyntaxError) {
+      errors.push(`${rel} is not valid JSON: ${error.message}`);
+    } else {
+      errors.push(`${rel} could not be read: ${error?.message || error}`);
+    }
+    return {};
+  }
 }
 
 function parseScalar(value) {
@@ -205,6 +217,7 @@ expectEqual('package.json license', pkg.license, book.license);
 expectEqual('package.json repository.url', normalizeRepoUrl(pkg.repository?.url), expectedRepoUrl);
 expectEqual('package.json homepage', pkg.homepage, expectedHomepage);
 expectEqual('package.json bugs.url', pkg.bugs?.url, `${expectedRepoUrl}/issues`);
+expectEqual('package.json scripts.check:security', pkg.scripts?.['check:security'], 'npm audit');
 expectEqual('package-lock root name', lock.packages?.['']?.name, pkg.name);
 expectEqual('package-lock root version', lock.packages?.['']?.version, pkg.version);
 expectEqual('package-lock root license', lock.packages?.['']?.license, pkg.license);
@@ -236,6 +249,9 @@ for (const [key, expected] of Object.entries({
 
 if (!readme.includes(expectedHomepage)) errors.push(`README.md must include canonical Pages URL: ${expectedHomepage}`);
 if (!readme.includes(book.title)) errors.push('README.md must include canonical book title');
+for (const command of ['npm ci', 'npm run check:security', 'npm test']) {
+  if (!readme.includes(command)) errors.push(`README.md must document local quality command: ${command}`);
+}
 
 const structureEntries = flattenStructure(book.structure);
 const seenIds = new Map();


### PR DESCRIPTION
## 概要
- `npm audit` を `check:security` として追加し、Book QA と Node.js build/deploy workflow で実行するようにしました。
- `gh-pages` の devDependency 範囲を現在の lockfile 実解決版に合わせ、`picomatch` を `2.3.2` に更新して既知脆弱性を解消しました。
- `package-lock.json` 欠落・不正時のメタデータ検証エラーを構造化し、README と `.gitignore` のローカルQA/生成物扱いを補強しました。

## スコープ
- 既存の open Issue #189（スクリーンショット取得・本文差し込み）は本文コンテンツ追加作業のため、本PRでは扱っていません。

## 検証
- `npm ci`
- `npm run check:security`（0 vulnerabilities）
- `npm run check:metadata`
- `npm test`
- `npm run build`
- `package-lock.json` 欠落の負例で `npm run check:metadata` が構造化エラーを返すこと
- `bundle exec jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/podman-jekyll-site`
- built site smoke: top / introduction / chapter01 / chapter10 / appendix-a
- workflow YAML parse（4 workflow）
- pinned `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` checks: unicode, textlint, links, layout-risk, markdown-structure
- `git diff --check`