### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -75,14 +75,32 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease;
   }
   
   /* Ensure sidebar content is interactive */

--- a/assets/css/mobile-responsive.css
+++ b/assets/css/mobile-responsive.css
@@ -97,25 +97,29 @@ html {
   }
 
   /* Show sidebar when toggled */
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar {
     transform: translateX(0) !important;
     visibility: visible;
     transition: transform 0.3s ease;
   }
   
   /* Ensure sidebar content is interactive */
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link {
     color: var(--text-secondary) !important;
     pointer-events: auto !important;
     cursor: pointer !important;
   }
   
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link:hover {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link:hover,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link:hover {
     background: var(--bg-secondary) !important;
     color: var(--text-primary) !important;
   }
   
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link.active {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link.active,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link.active {
     background: var(--bg-tertiary) !important;
     color: var(--primary-color) !important;
   }
@@ -132,7 +136,8 @@ html {
     pointer-events: none;
   }
 
-  .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay {
+  .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay,
+  body:has(.book-layout .sidebar-toggle-checkbox:checked) .book-sidebar-overlay {
     opacity: 1;
     visibility: visible;
     pointer-events: auto;

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -75,14 +75,32 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
+    visibility: hidden;
+    transition:
+      transform 0.3s ease,
+      visibility 0s linear 0.3s;
   }
 
   /* Show sidebar when toggled */
   .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
     transform: translateX(0) !important;
+    visibility: visible;
+    transition: transform 0.3s ease;
   }
   
   /* Ensure sidebar content is interactive */

--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -97,25 +97,29 @@ html {
   }
 
   /* Show sidebar when toggled */
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar {
     transform: translateX(0) !important;
     visibility: visible;
     transition: transform 0.3s ease;
   }
   
   /* Ensure sidebar content is interactive */
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link {
     color: var(--text-secondary) !important;
     pointer-events: auto !important;
     cursor: pointer !important;
   }
   
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link:hover {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link:hover,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link:hover {
     background: var(--bg-secondary) !important;
     color: var(--text-primary) !important;
   }
   
-  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link.active {
+  .sidebar-toggle-checkbox:checked ~ .book-layout .book-sidebar .toc-link.active,
+  .book-layout .sidebar-toggle-checkbox:checked ~ .book-sidebar .toc-link.active {
     background: var(--bg-tertiary) !important;
     color: var(--primary-color) !important;
   }
@@ -132,7 +136,8 @@ html {
     pointer-events: none;
   }
 
-  .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay {
+  .sidebar-toggle-checkbox:checked ~ .book-sidebar-overlay,
+  body:has(.book-layout .sidebar-toggle-checkbox:checked) .book-sidebar-overlay {
     opacity: 1;
     visibility: visible;
     pointer-events: auto;


### PR DESCRIPTION
## Summary
- Keep the mobile/tablet sidebar closed state off-canvas with an important transform so the later desktop `.book-sidebar { transform: translateX(0); }` rule in `main.css` cannot override it.
- Set the mobile drawer z-index to `999 !important`, above `.book-sidebar-overlay` (`950`) and below `.book-header` (`1000`).
- Hide the closed mobile/tablet drawer from the focus order with `visibility: hidden`, restoring visibility when opened.
- Scope: `docs/assets/css/mobile-responsive.css` for the configured Pages source (`main` `/docs`) and `assets/css/mobile-responsive.css` because the Node build copies root assets into `dist`.

## Verification
- `npm ci`
- `npm run check:security`
- `npm test`
- `git diff --check`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/podman-bundle-path BUNDLE_APP_CONFIG=/home/devuser/work/CodeX/booksB/.codex-local/tmp/podman-bundle-config bundle exec jekyll build --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/serve/podman-jekyll/podman-book`
- Local visual checker: `books=1 pages=10 ok=10 warn=0 fail=0`
- Direct Playwright z-index/visibility probe: `/` and `/chapters/chapter01/` at 480/768/820/1024/1280px; closed sidebar is off-canvas and hidden, opened drawer remains above overlay and below header, desktop layout remains unchanged.

## Portfolio issue
- Part of https://github.com/itdojp/it-engineer-knowledge-architecture/issues/168
