### PR TITLE
[codex] Update Podman Book QA Pages runtime

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -96,7 +96,7 @@ jobs:
           path: ${{ runner.temp }}/layout-risk-report.json
           if-no-files-found: ignore
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
## Summary
- update Book QA's GitHub Pages setup action from `actions/configure-pages@v5` to `actions/configure-pages@v6`
- keep the existing Node 20 QA baseline, `actions/*@v6/v7`, and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` setting intact
- scope is workflow runtime hygiene only; this does not address or close the screenshot tracker issue #189

Refs itdojp/it-engineer-knowledge-architecture#170.

## Validation
- confirmed current action tags exist via GitHub API: `actions/configure-pages@v6`, `actions/checkout@v6`, `actions/upload-artifact@v7`, `actions/setup-node@v6`, `actions/jekyll-build-pages@v1`
- parsed all `.github/workflows/*.yml` files with PyYAML
- confirmed no remaining `actions/configure-pages@v5`, `actions/checkout@v4`, or `actions/upload-artifact@v4` references in `.github/workflows/`
- `npm ci`
- `npm test`
- `git diff --check`
