### PR TITLE
feat: 公開図表6件の図表索引を追加

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Metadata consistency check
         run: npm run check:metadata
 
+      - name: Figure index contract check
+        run: npm run check:figure-index
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
 
     - name: Metadata consistency check
       run: npm run check:metadata
+
+    - name: Figure index contract check
+      run: npm run check:figure-index
         
     - name: Build book
       run: npm run build

--- a/book-config.json
+++ b/book-config.json
@@ -163,7 +163,7 @@
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": false,
+      "figureIndex": true,
       "legalNotice": false,
       "glossary": false
     }

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -32,6 +32,9 @@ chapters:
   path: /chapters/chapter14/
 - title: 第15章：トラブルシューティング完全ガイド
   path: /chapters/chapter15/
+additional:
+- title: 図表索引
+  path: /additional/figure-index/
 appendices:
 - title: 付録A：コマンドリファレンス
   path: /appendices/appendix-a/

--- a/docs/additional/figure-index.md
+++ b/docs/additional/figure-index.md
@@ -1,0 +1,52 @@
+---
+layout: book
+title: "図表索引"
+---
+
+# 図表索引
+
+本索引は、公開本文で実際に参照される図表を横断して確認するための入口です。未参照の素材、資産管理用のファイル、および今後追加予定のスクリーンショットは掲載しません。
+
+## [図1：コンテナ技術の構成概念]({{ '/chapters/chapter01/#figure-container-technology-concepts' | relative_url }})
+
+- **掲載箇所**: 第1章
+- **種別**: Mermaid
+- **目的**: Docker と Podman の構成を比較する
+- **見るべき点**: Podman がデーモンレスで、各コンテナをユーザー権限で管理する構成
+
+## [図2：切り分けフロー]({{ '/additional/troubleshooting-guide/#figure-troubleshooting-flow' | relative_url }})
+
+- **掲載箇所**: 実践的トラブルシューティングガイド
+- **種別**: Mermaid
+- **目的**: 障害発生時の初期切り分けを整理する
+- **見るべき点**: 起動、ネットワーク、性能の順に確認し、原因領域を絞り込む流れ
+
+## [図3：Podman確認画面]({{ '/chapters/chapter02/#figure-podman-verification-screen' | relative_url }})
+
+- **掲載箇所**: 第2章
+- **種別**: PNG
+- **目的**: インストール後の基本動作確認の出力例を示す
+- **見るべき点**: `podman --version`、`podman info`、`hello-world` の結果は環境により変わる点
+
+## [図4：コンテナライフサイクル]({{ '/chapters/chapter04/#figure-container-lifecycle' | relative_url }})
+
+- **掲載箇所**: 第4章
+- **種別**: SVG
+- **目的**: コンテナ状態と状態遷移を理解する
+- **見るべき点**: Created、Running、Paused など各状態で可能な操作と復旧判断
+
+## [図5：Podmanネットワーク]({{ '/chapters/chapter06/#figure-podman-network' | relative_url }})
+
+- **掲載箇所**: 第6章
+- **種別**: SVG
+- **目的**: ネットワークドライバーの構成を把握する
+- **見るべき点**: Bridge、Host、None、Macvlan の分離性と適用場面
+
+## [図6：セキュリティ層]({{ '/chapters/chapter08/#figure-security-layers' | relative_url }})
+
+- **掲載箇所**: 第8章
+- **種別**: SVG
+- **目的**: 多層防御を構成するセキュリティ機能を整理する
+- **見るべき点**: Namespace、Capabilities、Seccomp、SELinux/AppArmor、ユーザー名前空間の役割
+
+図表は本文の説明と併せて参照してください。図表単体は構成や判断の要点を示すものであり、設定値や操作手順の完全な代替ではありません。

--- a/docs/additional/troubleshooting-guide.md
+++ b/docs/additional/troubleshooting-guide.md
@@ -10,6 +10,8 @@ title: "Podman実践的トラブルシューティングガイド"
 
 ### 診断フローチャート
 
+<a id="figure-troubleshooting-flow"></a>
+
 ```mermaid
 graph TD
     A[問題発生] --> B{コンテナ起動?}

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -56,6 +56,8 @@ Podmanは従来のDockerとは大きく異なるアーキテクチャを採用�
 
 ### アーキテクチャの詳細比較
 
+<a id="figure-container-technology-concepts"></a>
+
 ```mermaid
 graph TB
     subgraph "従来のDocker"

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -146,6 +146,8 @@ podman info
 podman run --rm hello-world
 ```
 
+<a id="figure-podman-verification-screen"></a>
+
 ![Podman セットアップ確認の出力例](../../assets/images/screenshots/chapter02/01-podman-verify-setup.png)
 
 _Ubuntu 24.04 / Podman 4.9.3 における `podman --version` / `podman info` / `podman run --rm hello-world` の出力例。表示内容は環境により異なります。_

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -30,6 +30,8 @@ title: "第4章：イメージの管理と作成"
 
 #### 4.1.1 基本的なライフサイクル
 
+<a id="figure-container-lifecycle"></a>
+
 ![Container Lifecycle States](../../assets/images/diagrams/chapter04-container-lifecycle-states.svg)
 
 **各状態の意味と実務での使い分け**

--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -62,6 +62,8 @@ podman network ls
 
 各ネットワークドライバーの動作を視覚的に理解しましょう。
 
+<a id="figure-podman-network"></a>
+
 ![Podman Network Architecture](../../assets/images/diagrams/chapter06-podman-network-architecture.svg)
 
 **ネットワークドライバー比較表：**

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -27,6 +27,8 @@ title: "第8章：Dockerfileの作成と最適化"
 
 コンテナセキュリティは、単一の技術ではなく、複数のレイヤーで実現されます。
 
+<a id="figure-security-layers"></a>
+
 ![Container Security Layer Architecture](../../assets/images/diagrams/chapter08-security-layer-architecture.svg)
 
 各層での防御が、全体のセキュリティを構成します。

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ order: 0
 - **Docker からの移行を先に確認したい場合**: [Docker→Podman包括的移行ガイドライン]({{ '/additional/migration-guide/' | relative_url }}) → [第7章：Pod機能と複数コンテナ管理]({{ '/chapters/chapter07/' | relative_url }}) → [第10章：CI/CDパイプラインの実践]({{ '/chapters/chapter10/' | relative_url }})
 - **障害対応を優先したい場合**: [付録B：トラブルシューティングガイド]({{ '/appendices/appendix-b/' | relative_url }}) → [Podman実践的トラブルシューティングガイド]({{ '/additional/troubleshooting-guide/' | relative_url }}) → [第15章：トラブルシューティング完全ガイド]({{ '/chapters/chapter15/' | relative_url }})
 - **企業導入の論点を先に確認したい場合**: [エンタープライズ環境でのPodman要件詳細]({{ '/additional/enterprise-requirements/' | relative_url }}) → [第14章：エンタープライズ環境での活用]({{ '/chapters/chapter14/' | relative_url }}) → [付録C：リソース集]({{ '/appendices/appendix-c/' | relative_url }})
+- **図表を横断して確認したい場合**: [図表索引]({{ '/additional/figure-index/' | relative_url }})
 
 ## 安全に使うための注意
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dev": "npm run build && npm run serve",
     "check:metadata": "node scripts/check-metadata-consistency.js",
     "check:security": "npm audit",
-    "test": "npm run check:metadata && npm run build"
+    "check:figure-index": "node scripts/check-figure-index.js",
+    "test": "npm run check:metadata && npm run check:figure-index && npm run build"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0"

--- a/scripts/check-figure-index.js
+++ b/scripts/check-figure-index.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/* Validate the reader-facing figure index and its published figure inventory. */
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const docsRoot = path.join(repoRoot, 'docs');
+const figureIndexPath = 'docs/additional/figure-index.md';
+const figureIndexRoute = '/additional/figure-index/';
+const expectedFigures = [
+  {
+    id: 'figure-container-technology-concepts',
+    title: '図1：コンテナ技術の構成概念',
+    source: 'docs/chapters/chapter01/index.md',
+    route: '/chapters/chapter01/',
+    kind: 'Mermaid',
+    marker: '```mermaid',
+  },
+  {
+    id: 'figure-troubleshooting-flow',
+    title: '図2：切り分けフロー',
+    source: 'docs/additional/troubleshooting-guide.md',
+    route: '/additional/troubleshooting-guide/',
+    kind: 'Mermaid',
+    marker: '```mermaid',
+  },
+  {
+    id: 'figure-podman-verification-screen',
+    title: '図3：Podman確認画面',
+    source: 'docs/chapters/chapter02/index.md',
+    route: '/chapters/chapter02/',
+    kind: 'PNG',
+    marker: '![Podman セットアップ確認の出力例](../../assets/images/screenshots/chapter02/01-podman-verify-setup.png)',
+    asset: 'docs/assets/images/screenshots/chapter02/01-podman-verify-setup.png',
+  },
+  {
+    id: 'figure-container-lifecycle',
+    title: '図4：コンテナライフサイクル',
+    source: 'docs/chapters/chapter04/index.md',
+    route: '/chapters/chapter04/',
+    kind: 'SVG',
+    marker: '![Container Lifecycle States](../../assets/images/diagrams/chapter04-container-lifecycle-states.svg)',
+    asset: 'docs/assets/images/diagrams/chapter04-container-lifecycle-states.svg',
+  },
+  {
+    id: 'figure-podman-network',
+    title: '図5：Podmanネットワーク',
+    source: 'docs/chapters/chapter06/index.md',
+    route: '/chapters/chapter06/',
+    kind: 'SVG',
+    marker: '![Podman Network Architecture](../../assets/images/diagrams/chapter06-podman-network-architecture.svg)',
+    asset: 'docs/assets/images/diagrams/chapter06-podman-network-architecture.svg',
+  },
+  {
+    id: 'figure-security-layers',
+    title: '図6：セキュリティ層',
+    source: 'docs/chapters/chapter08/index.md',
+    route: '/chapters/chapter08/',
+    kind: 'SVG',
+    marker: '![Container Security Layer Architecture](../../assets/images/diagrams/chapter08-security-layer-architecture.svg)',
+    asset: 'docs/assets/images/diagrams/chapter08-security-layer-architecture.svg',
+  },
+];
+
+function countOccurrences(text, value) {
+  return text.split(value).length - 1;
+}
+
+function listPublishedMarkdown(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'assets' ? [] : listPublishedMarkdown(fullPath);
+    return entry.isFile() && entry.name.endsWith('.md') ? [fullPath] : [];
+  });
+}
+
+function validateFigureIndex({ overrides = new Map() } = {}) {
+  const errors = [];
+  const read = (relativePath) => {
+    if (overrides.has(relativePath)) return overrides.get(relativePath);
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+  };
+  const fileExists = (relativePath) => {
+    if (overrides.has(relativePath)) return overrides.get(relativePath).length > 0;
+    const file = path.join(repoRoot, relativePath);
+    return fs.existsSync(file) && fs.statSync(file).isFile() && fs.statSync(file).size > 0;
+  };
+
+  let book;
+  try {
+    book = JSON.parse(read('book-config.json'));
+  } catch (error) {
+    errors.push(`book-config.json is not readable JSON: ${error.message}`);
+    book = {};
+  }
+  if (book.ux?.modules?.figureIndex !== true) {
+    errors.push('book-config.json ux.modules.figureIndex must be true');
+  }
+
+  let packageJson;
+  try {
+    packageJson = JSON.parse(read('package.json'));
+  } catch (error) {
+    errors.push(`package.json is not readable JSON: ${error.message}`);
+    packageJson = {};
+  }
+  if (packageJson.scripts?.['check:figure-index'] !== 'node scripts/check-figure-index.js') {
+    errors.push('package.json must define check:figure-index');
+  }
+  if (!packageJson.scripts?.test?.includes('npm run check:figure-index')) {
+    errors.push('package.json test must run check:figure-index');
+  }
+
+  if (!fileExists(figureIndexPath)) {
+    errors.push(`${figureIndexPath} is missing or empty`);
+    return errors;
+  }
+  const indexText = read(figureIndexPath);
+  for (const required of ['layout: book', 'title: "図表索引"', '# 図表索引']) {
+    if (!indexText.includes(required)) errors.push(`${figureIndexPath} is missing ${JSON.stringify(required)}`);
+  }
+
+  const navigationText = read('docs/_data/navigation.yml');
+  if (!navigationText.includes('additional:\n- title: 図表索引\n  path: /additional/figure-index/')) {
+    errors.push('docs/_data/navigation.yml must register the figure index in additional');
+  }
+  const chapter15Position = navigationText.indexOf('path: /chapters/chapter15/');
+  const figureIndexPosition = navigationText.indexOf(`path: ${figureIndexRoute}`);
+  const appendixAPosition = navigationText.indexOf('path: /appendices/appendix-a/');
+  if (!(chapter15Position >= 0 && figureIndexPosition > chapter15Position && appendixAPosition > figureIndexPosition)) {
+    errors.push('figure index must be between chapter15 and appendix-a in navigation for prev/next');
+  }
+  if (!read('docs/_includes/sidebar-nav.html').includes('navigation.additional')) {
+    errors.push('sidebar navigation does not render the additional section');
+  }
+  if (!read('docs/_includes/page-navigation.html').includes('navigation.additional')) {
+    errors.push('page navigation does not sequence the additional section');
+  }
+  if (!read('docs/index.md').includes(figureIndexRoute)) {
+    errors.push('docs/index.md must link to the figure index');
+  }
+
+  const indexedLinks = [...indexText.matchAll(/\]\(\{\{\s*'([^']+#figure-[^']+)'\s*\\?\|\s*relative_url\s*\}\}\)/g)]
+    .map((match) => match[1]);
+  const expectedLinks = expectedFigures.map((figure) => `${figure.route}#${figure.id}`);
+  if (JSON.stringify(indexedLinks) !== JSON.stringify(expectedLinks)) {
+    errors.push(`figure index links must be the exact six-item inventory: expected ${expectedLinks.join(', ')}, got ${indexedLinks.join(', ')}`);
+  }
+  if (indexText.match(/\]\(\{\{\s*'[^']+#figure-/g)?.length !== expectedFigures.length) {
+    errors.push('figure index must contain exactly six stable-anchor links');
+  }
+  if (/assets\/images\/.+\.(?:png|svg)/i.test(indexText)) {
+    errors.push('figure index must link to reader-facing pages, not assets directly');
+  }
+
+  const figureAnchorIds = [];
+  for (const figure of expectedFigures) {
+    if (!indexText.includes(figure.title)) errors.push(`figure index is missing ${figure.title}`);
+    if (!fileExists(figure.source)) {
+      errors.push(`${figure.source} is missing or empty`);
+      continue;
+    }
+    const sourceText = read(figure.source);
+    const anchor = `<a id="${figure.id}"></a>`;
+    if (countOccurrences(sourceText, anchor) !== 1) {
+      errors.push(`${figure.source} must contain exactly one stable anchor ${figure.id}`);
+    }
+    if (!sourceText.includes(`${anchor}\n\n${figure.marker}`)) {
+      errors.push(`${figure.source} must place ${figure.id} immediately before its ${figure.kind} figure`);
+    }
+    figureAnchorIds.push(figure.id);
+    if (figure.asset && !fileExists(figure.asset)) {
+      errors.push(`${figure.asset} is missing or empty`);
+    }
+  }
+
+  const publishedTexts = listPublishedMarkdown(docsRoot)
+    .map((file) => ({ file: path.relative(repoRoot, file), text: read(path.relative(repoRoot, file)) }));
+  const actualAnchors = publishedTexts
+    .flatMap(({ text }) => [...text.matchAll(/<a id="(figure-[^"]+)"><\/a>/g)].map((match) => match[1]))
+    .sort();
+  const expectedAnchors = [...figureAnchorIds].sort();
+  if (JSON.stringify(actualAnchors) !== JSON.stringify(expectedAnchors)) {
+    errors.push(`published figure anchors must be exact: expected ${expectedAnchors.join(', ')}, got ${actualAnchors.join(', ')}`);
+  }
+
+  const mermaidCount = publishedTexts
+    .reduce((count, { text }) => count + (text.match(/^```mermaid$/gm)?.length || 0), 0);
+  if (mermaidCount !== 2) errors.push(`published Mermaid inventory must contain exactly 2 figures, got ${mermaidCount}`);
+
+  const expectedAssets = expectedFigures.filter((figure) => figure.asset).map((figure) => figure.asset).sort();
+  const actualAssets = publishedTexts
+    .flatMap(({ file, text }) => [...text.matchAll(/!\[[^\]]*\]\(([^)]+\.(?:png|svg))\)/gi)].map((match) => {
+      const resolved = path.normalize(path.join(path.dirname(path.join(repoRoot, file)), match[1]));
+      return path.relative(repoRoot, resolved);
+    }))
+    .sort();
+  if (JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) {
+    errors.push(`published PNG/SVG inventory must be exact: expected ${expectedAssets.join(', ')}, got ${actualAssets.join(', ')}`);
+  }
+
+  return errors;
+}
+
+function fail(errors) {
+  console.error('Figure index check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+if (require.main === module) {
+  const errors = validateFigureIndex();
+  if (errors.length) fail(errors);
+
+  if (process.argv.includes('--self-test')) {
+    const readFixture = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    const fixtures = [
+      {
+        name: 'flag',
+        overrides: new Map([['book-config.json', readFixture('book-config.json').replace('"figureIndex": true', '"figureIndex": false')]]),
+        expectedError: 'figureIndex must be true',
+      },
+      {
+        name: 'route',
+        overrides: new Map([['docs/_data/navigation.yml', readFixture('docs/_data/navigation.yml').replace('path: /additional/figure-index/', 'path: /additional/removed-figure-index/')]]),
+        expectedError: 'must register the figure index',
+      },
+      {
+        name: 'page',
+        overrides: new Map([[figureIndexPath, '']]),
+        expectedError: 'figure-index.md is missing or empty',
+      },
+      {
+        name: 'inventory',
+        overrides: new Map([[figureIndexPath, readFixture(figureIndexPath).replace('#figure-security-layers', '#figure-unplanned')]]),
+        expectedError: 'exact six-item inventory',
+      },
+      {
+        name: 'anchor',
+        overrides: new Map([['docs/additional/troubleshooting-guide.md', readFixture('docs/additional/troubleshooting-guide.md').replace('<a id="figure-troubleshooting-flow"></a>\n\n', '')]]),
+        expectedError: 'figure-troubleshooting-flow',
+      },
+      {
+        name: 'asset',
+        overrides: new Map([['docs/assets/images/diagrams/chapter04-container-lifecycle-states.svg', '']]),
+        expectedError: 'chapter04-container-lifecycle-states.svg is missing or empty',
+      },
+    ];
+    for (const fixture of fixtures) {
+      const fixtureErrors = validateFigureIndex({ overrides: fixture.overrides });
+      if (!fixtureErrors.some((error) => error.includes(fixture.expectedError))) {
+        fail([`negative fixture did not reject ${fixture.name}`]);
+      }
+    }
+    console.log('✅ Figure index negative fixtures passed (flag, route, page, inventory, anchor, and asset drift were rejected).');
+  }
+
+  console.log(`✅ Figure index check passed (${expectedFigures.length} figures: Mermaid 2, PNG 1, SVG 3).`);
+}
+
+module.exports = { expectedFigures, validateFigureIndex };

--- a/scripts/check-figure-index.js
+++ b/scripts/check-figure-index.js
@@ -74,6 +74,36 @@ function listPublishedMarkdown(dir) {
   });
 }
 
+function parseNavigation(text) {
+  const entries = [];
+  let section = null;
+  let current = null;
+  const unquote = (value) => value.trim().replace(/^(['"])(.*)\1$/, '$2');
+  const flush = () => {
+    if (current?.title && current?.path) entries.push({ section, ...current });
+    current = null;
+  };
+
+  for (const line of text.split(/\r?\n/)) {
+    const sectionMatch = line.match(/^([A-Za-z0-9_-]+):\s*$/);
+    if (sectionMatch) {
+      flush();
+      section = sectionMatch[1];
+      continue;
+    }
+    const titleMatch = line.match(/^\s*-\s*title:\s*(.+?)\s*$/);
+    if (titleMatch) {
+      flush();
+      current = { title: unquote(titleMatch[1]) };
+      continue;
+    }
+    const pathMatch = line.match(/^\s+path:\s*(\S+)\s*$/);
+    if (pathMatch && current) current.path = unquote(pathMatch[1]);
+  }
+  flush();
+  return entries;
+}
+
 function validateFigureIndex({ overrides = new Map() } = {}) {
   const errors = [];
   const read = (relativePath) => {
@@ -82,8 +112,12 @@ function validateFigureIndex({ overrides = new Map() } = {}) {
   };
   const fileExists = (relativePath) => {
     if (overrides.has(relativePath)) return overrides.get(relativePath).length > 0;
-    const file = path.join(repoRoot, relativePath);
-    return fs.existsSync(file) && fs.statSync(file).isFile() && fs.statSync(file).size > 0;
+    try {
+      const stat = fs.statSync(path.join(repoRoot, relativePath));
+      return stat.isFile() && stat.size > 0;
+    } catch {
+      return false;
+    }
   };
 
   let book;
@@ -121,12 +155,16 @@ function validateFigureIndex({ overrides = new Map() } = {}) {
   }
 
   const navigationText = read('docs/_data/navigation.yml');
-  if (!navigationText.includes('additional:\n- title: 図表索引\n  path: /additional/figure-index/')) {
+  const navigation = parseNavigation(navigationText);
+  const figureIndexEntries = navigation.filter(({ section, title, path: route }) => (
+    section === 'additional' && title === '図表索引' && route === figureIndexRoute
+  ));
+  if (figureIndexEntries.length !== 1) {
     errors.push('docs/_data/navigation.yml must register the figure index in additional');
   }
-  const chapter15Position = navigationText.indexOf('path: /chapters/chapter15/');
-  const figureIndexPosition = navigationText.indexOf(`path: ${figureIndexRoute}`);
-  const appendixAPosition = navigationText.indexOf('path: /appendices/appendix-a/');
+  const chapter15Position = navigation.findIndex(({ path: route }) => route === '/chapters/chapter15/');
+  const figureIndexPosition = navigation.findIndex(({ path: route }) => route === figureIndexRoute);
+  const appendixAPosition = navigation.findIndex(({ path: route }) => route === '/appendices/appendix-a/');
   if (!(chapter15Position >= 0 && figureIndexPosition > chapter15Position && appendixAPosition > figureIndexPosition)) {
     errors.push('figure index must be between chapter15 and appendix-a in navigation for prev/next');
   }
@@ -192,7 +230,7 @@ function validateFigureIndex({ overrides = new Map() } = {}) {
   const actualAssets = publishedTexts
     .flatMap(({ file, text }) => [...text.matchAll(/!\[[^\]]*\]\(([^)]+\.(?:png|svg))\)/gi)].map((match) => {
       const resolved = path.normalize(path.join(path.dirname(path.join(repoRoot, file)), match[1]));
-      return path.relative(repoRoot, resolved);
+      return path.relative(repoRoot, resolved).split(path.sep).join('/');
     }))
     .sort();
   if (JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) {


### PR DESCRIPTION
## 概要

- 公開本文の図表を全体走査し、Mermaid 2件・PNG 1件・SVG 3件の exact 6 inventory を図表索引として追加
- 各図の直前に stable anchor を設け、掲載箇所・目的・確認観点へ直接到達できるようにした
- top / sidebar / prev-next / `book-config.json` の reader UX 契約を同期
- flag / route / page / exact inventory / anchor / asset の回帰検査をローカルテストと PR/main CI の両方へ接続

## スコープ境界

- #189 のスクリーンショット拡充、#207 の章構成同期、#208 の Sass/Jekyll toolchain は変更していません
- 未参照画像や将来候補は索引に含めていません

## 検証

- `npm test`
- `npm audit --audit-level=moderate`（0 vulnerabilities）
- `node scripts/check-figure-index.js --self-test`
- `bundle exec jekyll build --source docs`
- rendered route で deep link / target anchor exact 6 を確認
- `git diff --cached --check`

Closes #210
