### PR TITLE
docs: Podmanのstorage/network backendを現行仕様へ更新

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Figure index contract check
         run: npm run check:figure-index
 
+      - name: Podman backend contract check
+        run: npm run check:podman-backends
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
 
     - name: Figure index contract check
       run: npm run check:figure-index
+
+    - name: Podman backend contract check
+      run: npm run check:podman-backends
         
     - name: Build book
       run: npm run build

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -172,7 +172,7 @@ $ podman info --format json | jq '{
 
 ```bash
 # 現在のbackendを確認。現行Podmanの通常buildではNetavark
-$ podman info --format '\{\{.Host.NetworkBackend\}\}'
+{% raw %}$ podman info --format '{{.Host.NetworkBackend}}'{% endraw %}
 netavark
 
 # 公開CLIでnetworkを作成

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -226,20 +226,34 @@ $ systemctl --user set-property user@1000.service \
 
 ### ストレージ最適化設定
 
-```bash
-# ストレージ設定ファイル
-$ cat ~/.config/containers/storage.conf
+native rootless OverlayFSを利用できる環境では、`mount_program`を設定しません。
+
+```toml
+# ~/.config/containers/storage.conf（native overlay）
 [storage]
 driver = "overlay"
 runroot = "/run/user/1000/containers"
 graphroot = "/home/user/.local/share/containers/storage"
 
 [storage.options.overlay]
-# native rootless OverlayFSを利用できない場合だけ指定
+mountopt = "nodev"
+```
+
+kernelまたはbacking filesystemの制約でnative overlayを利用できない場合だけ、fallbackとして次を追加します。
+
+```toml
+# ~/.config/containers/storage.conf（fuse-overlayfs fallback）
+[storage.options.overlay]
 mount_program = "/usr/bin/fuse-overlayfs"
 mountopt = "nodev"
+```
 
-# ストレージ使用状況の確認
+```bash
+# 選択結果とストレージ使用状況の確認
+$ podman info --format json | jq '{
+    graphDriver: .store.graphDriverName,
+    graphOptions: .store.graphOptions
+  }'
 $ podman system df
 TYPE           TOTAL   ACTIVE  SIZE    RECLAIMABLE
 Images         15      5       2.45GB  1.23GB (50%)
@@ -258,7 +272,7 @@ $ podman system prune
 
 **各ドライバーの特性と用途**
 
-```bash
+```toml
 # ~/.config/containers/storage.conf
 [storage]
 driver = "overlay"  # Podman / containers-storageでのdriver名
@@ -271,11 +285,10 @@ runroot = "/run/user/1000/containers"
 # - 高速な起動とビルド
 
 [storage.options.overlay]
-# native rootless OverlayFSを使える環境ではmount_programを指定しない
-# kernel / backing filesystemの制約でnative overlayを使えない場合だけ指定
-mount_program = "/usr/bin/fuse-overlayfs"
-# → fuseにより、user spaceでoverlay機能を提供
+mountopt = "nodev"
 ```
+
+上記はnative overlayの例です。fallbackが必要な環境だけ、別途`mount_program = "/usr/bin/fuse-overlayfs"`を`[storage.options.overlay]`へ追加します。native overlayの設定例へ`mount_program`をcopyしないでください。
 
 **storage quotaの適用境界**
 

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -145,89 +145,51 @@ $ ls -ln /tmp/test/file
 ### ストレージドライバーの選択
 
 ```bash
-# 現在のストレージドライバー確認
-$ podman info --format '\{\{.Store.GraphDriverName\}\}'
-overlay
+# rootless状態、kernel、storage driver、driver optionを同時に確認
+$ podman info --format json | jq '{
+    rootless: .host.security.rootless,
+    kernel: .host.kernel,
+    graphDriver: .store.graphDriverName,
+    graphRoot: .store.graphRoot,
+    graphOptions: .store.graphOptions
+  }'
 
-$ podman info --format '\{\{.Store.GraphOptions\}\}'
-overlay.mount_program=/usr/bin/fuse-overlayfs
-
-# パフォーマンス測定
-$ time podman pull docker.io/library/ubuntu:22.04
-
-# native overlay (カーネル5.11以降)
-real    0m8.234s
-
-# fuse-overlayfs
-real    0m12.456s
-
-# vfs (互換性重視)
-real    0m25.789s
+# 期待するdriver名はDockerのoverlay2ではなくoverlay
+{
+  "rootless": true,
+  "kernel": "<running-kernel>",
+  "graphDriver": "overlay",
+  "graphRoot": "/home/user/.local/share/containers/storage",
+  "graphOptions": {}
+}
 ```
 
-### ネットワーク設定の最適化
+`graphDriver`が`overlay`で、`graphOptions`に`overlay.mount_program`がなければnative overlayを使用しています。`overlay.mount_program`に`fuse-overlayfs`が記録されていればFUSE経由です。native rootless OverlayFSはLinux 5.12.9以降が前提ですが、kernel番号だけで決めず、backing filesystemとディストリビューションのsupport policyも確認します。
+
+`fuse-overlayfs`を導入しても、既存の`$HOME/.config/containers/storage.conf`があると自動選択されない場合があります。設定変更前に既存container/imageを退避し、変更後は`podman info`で実際に選択されたdriverとoptionを再確認してください。
+
+### network backendと設定の確認
 
 ```bash
-# Rootless CNIの設定
-$ cat ~/.config/containers/containers.conf
-[network]
-# CNIプラグインディレクトリ
-network_config_dir = "/home/user/.config/cni/net.d"
-cni_plugin_dirs = ["/usr/libexec/cni", "/usr/lib/cni"]
+# 現在のbackendを確認。現行Podmanの通常buildではNetavark
+$ podman info --format '\{\{.Host.NetworkBackend\}\}'
+netavark
 
-# デフォルトネットワーク
-default_network = "podman"
-
-# ネットワークバックエンド
-network_backend = "cni"  # または "netavark" (Podman 4.0+)
-
-# カスタムネットワークの作成
+# 公開CLIでnetworkを作成
 $ podman network create \
   --subnet 172.20.0.0/16 \
   --gateway 172.20.0.1 \
-  --ip-range 172.20.1.0/24 \
   custom-net
 
-# ネットワーク設定の確認
-$ cat ~/.config/cni/net.d/custom-net.conflist | jq .
-{
-  "cniVersion": "0.4.0",
-  "name": "custom-net",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "cni-podman1",
-      "isGateway": true,
-      "ipMasq": true,
-      "hairpinMode": true,
-      "ipam": {
-        "type": "host-local",
-        "routes": [{"dst": "0.0.0.0/0"}],
-        "ranges": [[
-          {
-            "subnet": "172.20.0.0/16",
-            "gateway": "172.20.0.1",
-            "rangeStart": "172.20.1.1",
-            "rangeEnd": "172.20.1.254"
-          }
-        ]]
-      }
-    },
-    {
-      "type": "portmap",
-      "capabilities": {
-        "portMappings": true
-      }
-    },
-    {
-      "type": "firewall"
-    },
-    {
-      "type": "tuning"
-    }
-  ]
-}
+# generated fileを直接読むのではなく、公開CLIで結果を確認
+$ podman network inspect custom-net | jq '.[0] | {
+    name, driver, network_interface, subnets, dns_enabled
+  }'
 ```
+
+Netavarkのnetwork config directoryは、rootfulでは`/etc/containers/networks`、rootlessでは`$graphroot/networks`です。`graphroot`の既定値は`$HOME/.local/share/containers/storage`ですが、固定pathを仮定せず`podman info`で確認します。generated JSONは内部実装として扱い、作成・変更・確認には`podman network` commandを使用します。
+
+Podman 4以前のCNI環境から移行する場合、CNIの`.conflist`をNetavark directoryへcopyしません。旧networkの接続containerと設定を記録し、現行Podman上でnetworkを再作成してから切り替えます。Podman 5.0ではCNI supportが通常buildで無効化され、Podman 6.0で削除されました。現行Podmanの新規設定でCNI backendを選択する手順は対象外です。
 
 ### cgroups v2の詳細設定
 
@@ -272,16 +234,10 @@ driver = "overlay"
 runroot = "/run/user/1000/containers"
 graphroot = "/home/user/.local/share/containers/storage"
 
-[storage.options]
-# マウントオプション
+[storage.options.overlay]
+# native rootless OverlayFSを利用できない場合だけ指定
 mount_program = "/usr/bin/fuse-overlayfs"
-mountopt = "nodev,metacopy=on"
-
-# イメージストアのサイズ制限
-size = "10G"
-
-# パフォーマンスオプション
-# skip_mount_home = "true"  # ホームディレクトリマウントをスキップ
+mountopt = "nodev"
 
 # ストレージ使用状況の確認
 $ podman system df
@@ -305,35 +261,25 @@ $ podman system prune
 ```bash
 # ~/.config/containers/storage.conf
 [storage]
-driver = "overlay"  # なぜoverlayを選ぶのか
+driver = "overlay"  # Podman / containers-storageでのdriver名
+graphroot = "/home/user/.local/share/containers/storage"
+runroot = "/run/user/1000/containers"
 
-# overlay: 最高のパフォーマンス、本番環境推奨
+# overlay: copy-on-writeによるlayer管理
 # - Copy-on-Write により効率的なレイヤー管理
 # - ハードリンクによる容量節約
 # - 高速な起動とビルド
 
 [storage.options.overlay]
-# Rootlessの場合はfuse-overlayfsが必要（なぜか）
+# native rootless OverlayFSを使える環境ではmount_programを指定しない
+# kernel / backing filesystemの制約でnative overlayを使えない場合だけ指定
 mount_program = "/usr/bin/fuse-overlayfs"
-# → カーネルのoverlayfsはroot権限が必要
-# → fuseにより、ユーザー空間で同等機能を実現
-
-# ストレージパスの意味
-graphroot = "$HOME/.local/share/containers/storage"  # イメージとレイヤー保存先
-runroot = "$XDG_RUNTIME_DIR/containers"  # 実行時の一時データ（高速なtmpfs推奨）
+# → fuseにより、user spaceでoverlay機能を提供
 ```
 
-**ストレージクォータ設定の必要性**
+**storage quotaの適用境界**
 
-```bash
-# なぜクォータが必要か
-# - ディスク容量の枯渇を防ぐ
-# - マルチユーザー環境での公平性確保
-# - 暴走したビルドプロセスからの保護
-
-[storage.options.vfs]
-size = "10G"  # ユーザーごとの上限設定
-```
+`size = "10G"`を`[storage.options.vfs]`へ置く方法は現行schemaにありません。quota optionはdriverごとに異なり、backing filesystem側のproject quotaなど追加要件もあります。設定前に[containers-storage.conf](https://github.com/podman-container-tools/container-libs/blob/main/storage/docs/containers-storage.conf.5.md)の対象driver節を確認し、`podman info`と実際の書き込み上限で検証します。
 
 #### 3.2.3 レジストリ設定
 
@@ -369,44 +315,33 @@ location = "mirror.gcr.io"  # 地理的に近いミラーで高速化
 
 ### 3.3 ネットワーク設定
 
-#### 3.3.1 CNIプラグイン
+#### 3.3.1 Netavarkとaardvark-dns
 
-**基本的なCNI設定**
-```json
-{
-  "cniVersion": "0.4.0",
-  "name": "podman",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "cni-podman0",
-      "isGateway": true,
-      "ipMasq": true,
-      "hairpinMode": true,
-      "ipam": {
-        "type": "host-local",
-        "routes": [{ "dst": "0.0.0.0/0" }],
-        "ranges": [
-          [
-            {
-              "subnet": "10.88.0.0/16",
-              "gateway": "10.88.0.1"
-            }
-          ]
-        ]
-      }
-    },
-    {
-      "type": "portmap",
-      "capabilities": {
-        "portMappings": true
-      }
-    },
-    {
-      "type": "firewall"
-    }
-  ]
-}
+Netavarkは現行Podmanのnetwork backendです。DNSが有効なnetworkではaardvark-dnsがcontainer名とnetwork aliasを登録します。rootless containerをdefault network modeで実行するときはpastaが使われます。
+
+```bash
+# backendとrootless network toolを確認
+$ podman info --format json | jq '{
+    backend: .host.networkBackend,
+    backendInfo: .host.networkBackendInfo,
+    rootless: .host.security.rootless,
+    pasta: .host.pasta
+  }'
+
+# bridge networkを作成し、driver / subnet / DNSを確認
+$ podman network create --subnet 10.89.10.0/24 app-net
+$ podman network inspect app-net | jq '.[0] | {
+    name, driver, network_interface, subnets, dns_enabled
+  }'
+
+# container名とaliasによるname解決を確認
+$ podman run -d --name web --network app-net docker.io/library/nginx:1.28.0-alpine
+$ podman run --rm --network app-net docker.io/library/busybox:1.37.0 \
+    nslookup web
+
+# 演習後のcleanup
+$ podman rm -f web
+$ podman network rm app-net
 ```
 
 #### 3.3.2 ファイアウォール統合
@@ -497,11 +432,18 @@ force_mask = "0700"
 
 1. Rootless Podmanをセットアップし、動作確認してください
 2. プライベートレジストリを設定し、イメージをプッシュしてください
-3. カスタムCNI設定を作成し、特定のIPレンジを使用してください
+3. `podman network create`でNetavarkのcustom networkを作成し、`podman network inspect`でsubnetとDNS設定を確認してください
 
 ### 参考資料
 
 エンタープライズ環境での詳細な要件については、[エンタープライズ要件詳細ガイド](../../additional/enterprise-requirements/)を参照してください。
+
+- [Podman rootless mode / storage](https://docs.podman.io/en/stable/markdown/podman.1.html#rootless-mode)
+- [podman network](https://docs.podman.io/en/stable/markdown/podman-network.1.html)
+- [podman info](https://docs.podman.io/en/stable/markdown/podman-info.1.html)
+- [Podman v5.0.0 release notes（CNI supportの通常build無効化）](https://github.com/podman-container-tools/podman/releases/tag/v5.0.0)
+- [Podman v6.0.0 release notes（CNI networkingの削除）](https://github.com/podman-container-tools/podman/releases/tag/v6.0.0)
+- [containers-storage.conf](https://github.com/podman-container-tools/container-libs/blob/main/storage/docs/containers-storage.conf.5.md)
 
 ## まとめ
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -117,19 +117,19 @@ struct uid_gid_extent {
 
 ### 動作環境要件
 
-**カーネル要件**：
-- Linux 4.18以上（cgroup v2フルサポート）
-- 有効化必須のカーネル機能：
-  - `CONFIG_USER_NS=y`
-  - `CONFIG_SECCOMP=y`
-  - `CONFIG_CGROUPS=y`
-  - `CONFIG_CGROUP_FREEZER=y`
-  - `CONFIG_CGROUP_DEVICE=y`
+**カーネル・ユーザー空間の要件**：
+- 単一のkernel versionだけを動作保証条件にはしません。利用するディストリビューションが対象Podman版をサポートしていることを先に確認します。
+- Rootless運用ではuser namespaceと`/etc/subuid`・`/etc/subgid`の割り当てが必要です。リソース制御を使う場合は、cgroup v2とsystemd user sessionへのdelegationも確認します。
+- native rootless OverlayFSの境界はLinux 5.12.9です。これより古いkernel、またはrootless OverlayFSを利用できないbacking filesystemでは、`fuse-overlayfs`か`vfs`を選びます。
+- NFSなどuser namespaceを扱えない分散filesystemはrootlessの`graphroot`にせず、local storageを使用します。
 
-**ファイルシステム要件**：
-- overlay2: 推奨、copy-on-writeによる高速化
-- fuse-overlayfs: rootless環境でのフォールバック
-- VFS: 互換性重視だが性能劣化
+**storage driverの要件**：
+- `overlay`: Podman / containers-storageでのdriver名です。Dockerのdriver名`overlay2`とは区別します。
+- native `overlay`: kernelとbacking filesystemが対応する場合の第一候補です。
+- `fuse-overlayfs`: native rootless OverlayFSを利用できない場合の`mount_program`です。既存の`$HOME/.config/containers/storage.conf`がある場合は自動選択されないことがあるため、実設定を`podman info`で確認します。
+- `vfs`: overlayを利用できない環境の互換手段ですが、copy-on-writeを使わないため容量と性能への影響を評価します。
+
+判定基準は[Podmanのrootless mode](https://docs.podman.io/en/stable/markdown/podman.1.html#rootless-mode)と、導入ディストリビューションのsupport policyを正本にします。
 
 ### 実装アーキテクチャ
 
@@ -149,8 +149,8 @@ struct uid_gid_extent {
             ┌──────────────┼──────────────┐
             │              │              │
      ┌──────▼──────┐┌──────▼──────┐┌─────▼──────┐
-     │    conmon   ││     CNI     ││    crun    │
-     │ (監視/ログ) ││(ネットワーク)││ (OCI実装) │
+     │    conmon   ││  Netavark   ││    crun    │
+     │ (監視/ログ) ││+aardvark-dns││ (OCI実装) │
      └─────────────┘└─────────────┘└────────────┘
                            │
                     ┌──────▼──────┐
@@ -162,6 +162,7 @@ struct uid_gid_extent {
 - **libpod**: Podmanコア、コンテナライフサイクル管理
 - **conmon**: コンテナモニター、stdio/ログ処理、終了コード取得
 - **crun**: OCI仕様準拠の軽量ランタイム（C実装、runcより50%高速）
-- **CNI**: プラグイン形式のネットワーク管理
+- **Netavark**: 現行Podmanのnetwork backend。bridge、port forwarding、network設定を管理
+- **aardvark-dns**: Netavark network内のcontainer名・aliasのname解決を担当
 
 本書では、これらの実装詳細と、プロダクション環境での最適な構成方法を解説します。

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "check:metadata": "node scripts/check-metadata-consistency.js",
     "check:security": "npm audit",
     "check:figure-index": "node scripts/check-figure-index.js",
-    "test": "npm run check:metadata && npm run check:figure-index && npm run build"
+    "check:podman-backends": "node scripts/check-podman-backend-contract.js && node scripts/check-podman-backend-contract-regression.js",
+    "test": "npm run check:metadata && npm run check:figure-index && npm run check:podman-backends && npm run build"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0"

--- a/scripts/check-podman-backend-contract-regression.js
+++ b/scripts/check-podman-backend-contract-regression.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/* Regression fixtures for the Podman backend contract. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { contracts, validateText } = require('./check-podman-backend-contract');
+
+const repoRoot = path.resolve(__dirname, '..');
+const baseline = Object.fromEntries(
+  Object.entries(contracts).map(([name, contract]) => [
+    name,
+    fs.readFileSync(path.join(repoRoot, contract.path), 'utf8'),
+  ])
+);
+
+const fixtures = [
+  ['overlay2-driver', 'introduction', baseline.introduction + '\n- overlay2: 推奨\n'],
+  ['stale-kernel-minimum', 'introduction', baseline.introduction + '\n- Linux 4.18以上\n'],
+  ['active-cni-backend', 'chapter03', baseline.chapter03 + '\nnetwork_backend = "cni"\n'],
+  ['legacy-rootless-cni-path', 'chapter03', baseline.chapter03 + '\n~/.config/cni/net.d/example.conflist\n'],
+  ['legacy-rootful-cni-path', 'chapter03', baseline.chapter03 + '\n/etc/cni/net.d/example.conflist\n'],
+  ['active-cni-heading', 'chapter03', baseline.chapter03 + '\n#### CNIプラグイン設定\n'],
+  ['active-cni-exercise', 'chapter03', baseline.chapter03 + '\nカスタムCNI設定を作成する\n'],
+  [
+    'missing-netavark-inspect',
+    'chapter03',
+    baseline.chapter03.replaceAll('podman network inspect', 'removed network inspection command'),
+  ],
+];
+
+for (const [label, contractName, text] of fixtures) {
+  if (validateText(text, contractName, label).length === 0) {
+    throw new Error(`negative fixture was accepted: ${label}`);
+  }
+}
+
+for (const [name, text] of Object.entries(baseline)) {
+  const errors = validateText(text, name, `baseline-${name}`);
+  if (errors.length) throw new Error(`valid baseline was rejected: ${errors.join('; ')}`);
+}
+
+console.log(`Podman backend regression fixtures: OK (${fixtures.length} negative, 2 positive)`);

--- a/scripts/check-podman-backend-contract-regression.js
+++ b/scripts/check-podman-backend-contract-regression.js
@@ -41,4 +41,6 @@ for (const [name, text] of Object.entries(baseline)) {
   if (errors.length) throw new Error(`valid baseline was rejected: ${errors.join('; ')}`);
 }
 
-console.log(`Podman backend regression fixtures: OK (${fixtures.length} negative, 2 positive)`);
+console.log(
+  `Podman backend regression fixtures: OK (${fixtures.length} negative, ${Object.keys(baseline).length} positive)`
+);

--- a/scripts/check-podman-backend-contract.js
+++ b/scripts/check-podman-backend-contract.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/* Validate the current Podman storage and network backend guidance. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+const contracts = {
+  introduction: {
+    path: 'docs/introduction/index.md',
+    required: [
+      'Linux 5.12.9',
+      'Podman / containers-storageでのdriver名',
+      '`fuse-overlayfs`',
+      'https://docs.podman.io/en/stable/markdown/podman.1.html#rootless-mode',
+      '**Netavark**',
+      '**aardvark-dns**',
+    ],
+  },
+  chapter03: {
+    path: 'docs/chapters/chapter03/index.md',
+    required: [
+      'podman info --format json',
+      "podman info --format '\\{\\{.Host.NetworkBackend\\}\\}'",
+      'podman network inspect',
+      '/etc/containers/networks',
+      '$graphroot/networks',
+      '#### 3.3.1 Netavarkとaardvark-dns',
+      'https://docs.podman.io/en/stable/markdown/podman-network.1.html',
+      'https://github.com/podman-container-tools/podman/releases/tag/v5.0.0',
+      'https://github.com/podman-container-tools/podman/releases/tag/v6.0.0',
+      'https://github.com/podman-container-tools/container-libs/blob/main/storage/docs/containers-storage.conf.5.md',
+    ],
+  },
+};
+
+const forbidden = [
+  {
+    label: 'Docker-specific storage driver configured as Podman storage',
+    pattern: /(?:^\s*-\s*`?overlay2`?\s*:|driver\s*=\s*["']overlay2["'])/im,
+  },
+  { label: 'universal Linux 4.18 minimum', pattern: /^\s*-\s*Linux\s*4\.18以上/im },
+  { label: 'active CNI backend setting', pattern: /network_backend\s*=\s*["']cni["']/i },
+  { label: 'legacy rootless CNI config path', pattern: /~\/\.config\/cni\/net\.d/i },
+  { label: 'legacy rootful CNI config path', pattern: /\/etc\/cni\/net\.d/i },
+  { label: 'active CNI plugin section', pattern: /^#{2,6}\s+.*CNIプラグイン/im },
+  { label: 'active CNI exercise', pattern: /カスタムCNI設定/ },
+  { label: 'active rootless CNI procedure', pattern: /Rootless\s*CNI/ },
+];
+
+function validateText(text, contractName, sourceLabel = contractName) {
+  const contract = contracts[contractName];
+  if (!contract) throw new Error(`unknown contract: ${contractName}`);
+  const errors = [];
+  for (const marker of contract.required) {
+    if (!text.includes(marker)) errors.push(`${sourceLabel}: missing required marker: ${marker}`);
+  }
+  for (const rule of forbidden) {
+    if (rule.pattern.test(text)) errors.push(`${sourceLabel}: forbidden ${rule.label}`);
+  }
+  return errors;
+}
+
+function validateRepository() {
+  const errors = [];
+  for (const [name, contract] of Object.entries(contracts)) {
+    const file = path.join(repoRoot, contract.path);
+    if (!fs.existsSync(file)) {
+      errors.push(`${contract.path}: file is missing`);
+      continue;
+    }
+    errors.push(...validateText(fs.readFileSync(file, 'utf8'), name, contract.path));
+  }
+  return errors;
+}
+
+function main() {
+  const errors = validateRepository();
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('Podman backend contract: OK (overlay + Netavark + aardvark-dns)');
+}
+
+if (require.main === module) main();
+
+module.exports = { contracts, validateRepository, validateText };

--- a/scripts/check-podman-backend-contract.js
+++ b/scripts/check-podman-backend-contract.js
@@ -24,7 +24,7 @@ const contracts = {
     path: 'docs/chapters/chapter03/index.md',
     required: [
       'podman info --format json',
-      "podman info --format '\\{\\{.Host.NetworkBackend\\}\\}'",
+      "{% raw %}$ podman info --format '{{.Host.NetworkBackend}}'{% endraw %}",
       'podman network inspect',
       '/etc/containers/networks',
       '$graphroot/networks',


### PR DESCRIPTION
## 変更概要

- Podmanのstorage driver名をDocker由来の`overlay2`から`overlay`へ修正
- rootless native OverlayFSのLinux 5.12.9境界、backing filesystem、`fuse-overlayfs` fallback条件を明記
- 一律のkernel最小値を廃止し、distribution support / user namespace / cgroup v2 / storage条件で判定する手順へ変更
- introductionのnetwork componentをCNIからNetavark / aardvark-dnsへ更新
- Chapter 3のCNI active設定とraw `.conflist`確認を、Netavark既定・`podman info`・`podman network create/inspect`へ置換
- Podman 5.0のCNI通常build無効化、Podman 6.0のCNI削除をmigration境界として明示
- stale backend手順の再導入を拒否するQA contractと8 negative / 2 positive regression fixturesを`npm test`へ追加

## 一次情報監査

- review時点の公式latest: Podman v6.0.1（2026-07-08）
- Podman stable rootless/storage man page
- Podman stable network/info man page
- Podman v5.0.0 / v6.0.0 release notes
- current containers-storage.conf schema
- v6.0.1公式remote static binaryのSHA-256をrelease `shasums`で確認し、CLI versionとnetwork create/inspect optionを確認

## 検証

- `npm ci` / full `npm audit`: vulnerability 0
- `npm test`: metadata 20 routes、figure index 6 figures、backend contract、regression 8 negative / 2 positive、build成功
- local Podman 4.9.3 rootless実行確認: backend `netavark`、storage `overlay`、一時networkのcreate/inspect/remove成功
- pinned book-formatter `69eb5c12...`: Unicode / Textlint / Links / Layout / Structure error 0
- Bundler / Jekyll build: 成功、introduction / Chapter 3 marker確認
- 公式URL 5件: HTTP 200
- `git diff --check` / Node syntax check: 成功

## Scope

- Issue #207の章構成、Issue #189の画像には変更なし
- Chapter 6 / 15等に残る別文脈のlegacy CNI記述は本Issueの明示scope外。重複監査後に別Issueで扱う

Closes #214
