### PR TITLE
docs: Podman machineとdirect WSL2の導入経路を分離

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Podman backend contract check
         run: npm run check:podman-backends
 
+      - name: Podman machine path contract check
+        run: npm run check:podman-machine-paths
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
 
     - name: Podman backend contract check
       run: npm run check:podman-backends
+
+    - name: Podman machine path contract check
+      run: npm run check:podman-machine-paths
         
     - name: Build book
       run: npm run build

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -30,8 +30,8 @@ Podmanは従来のDockerとは大きく異なるアーキテクチャを採用�
 | **Pod機能** | ◎ Kubernetes互換 | × なし | K8s移行予定→Podman |
 | **systemd統合** | ◎ ネイティブ | △ 外部ツール必要 | RHEL/CentOS環境→Podman |
 | **SELinux統合** | ◎ 完全対応 | △ 追加設定要 | セキュリティ要件高→Podman |
-| **Windows対応** | △ WSL2経由 | ◎ ネイティブ | Windows中心→Docker |
-| **macOS対応** | △ VM経由 | ◎ Docker Desktop | macOS開発→Docker |
+| **Windows対応** | ○ native CLI + Podman machine（WSL / Hyper-V guest） | ◎ Docker Desktop | providerと既存toolchainで選択 |
+| **macOS対応** | ○ native CLI + Podman machine（Linux VM） | ◎ Docker Desktop | どちらもLinux VMを使用 |
 | **イメージ互換性** | ◎ OCI準拠 | ◎ OCI準拠 | 両者で相互利用可能 |
 | **docker compose** | ○ podman-compose | ◎ ネイティブ | 既存compose資産→Docker |
 | **Swarmモード** | × なし | ◎ 内蔵 | Swarm利用中→Docker |

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -6,10 +6,12 @@ title: "第2章：Podmanのインストールと初期設定"
 
 # 第2章：Podmanのインストールと初期設定
 
-## 対象バージョン
-- **Podman**: 5.0.x（2024年3月リリース）
-- **動作確認OS**: RHEL 9.3、Ubuntu 22.04 LTS、CentOS Stream 9、Fedora 39
-- **前提条件**: Linux Kernel 4.18+、cgroup v2対応、systemd 239+（rootless時）
+## 検証基準と環境
+
+- **platform導入手順**: Podman stable文書とv6.0.1（2026-07-08公開）で確認（2026-07-21）
+- **Linux実行例**: Ubuntu 24.04 / Podman 4.9.3で確認。distribution packageのversionはOS releaseごとに異なるため、固定値を期待せず`podman --version`で記録します。
+- **desktop前提**: macOS / Windowsではhost側CLIがPodman machine内のLinux Podmanへremote接続します。Windows向け現行公式guideはWindows 11以降を前提とします。
+- **rootless前提**: 一般userで実行する本章のLinux例とmachine guestはrootlessを基準にします。`sudo podman`やmachineをrootfulへ切り替えた場合は、storage、image、containerの表示範囲がrootless側と分かれることを確認します。
 
 ## 2.1 自動インストールスクリプト
 
@@ -118,7 +120,7 @@ echo "  podman run -it alpine sh"
 ### RHEL/CentOS/Fedora
 
 ```bash
-# DNFを使用したインストール（Podman 5.0.x）
+# DNFを使用したインストール
 sudo dnf install -y podman
 
 # 関連ツールのインストール
@@ -126,7 +128,7 @@ sudo dnf install -y buildah skopeo podman-compose
 
 # バージョン確認と動作テスト
 podman --version
-# 期待される出力: podman version 5.0.x
+# distributionが提供するversionを記録
 
 # 基本的な動作確認
 podman run --rm hello-world
@@ -154,28 +156,74 @@ _Ubuntu 24.04 / Podman 4.9.3 における `podman --version` / `podman info` / `
 
 ### macOS
 
+macOSではhost側の`podman` CLIから、Podman machineが管理するLinux VMへ接続する経路を標準とします。公式installerを使用し、利用するreleaseとchecksumを記録してください。Homebrew版はcommunity-maintainedであり、Podman公式の推奨導入経路ではありません。
+
 ```bash
-# Homebrewを使用
-brew install podman
+# 公式installerを導入した新しいterminalで確認
+podman --version
 
-# Podman machineの初期化
-podman machine init
-podman machine start
+# Podman machine（標準経路）を作成して起動
+podman machine init --now
 
-# 接続確認
-podman info
+# host側machineとremote接続先を確認
+podman machine list
+podman machine inspect
+podman system connection list
+podman info --format json
 ```
+
+`podman machine inspect`の`State`が`running`、`Rootful`が`false`であることを確認します。`podman info --format json`ではguest側の情報と`serviceIsRemote`を確認します。machine providerはPodman versionとhost architectureで変わり得るため、固定値を仮定せず`podman machine info`と[podman-machine公式文書](https://docs.podman.io/en/stable/markdown/podman-machine.1.html)で確認します。
 
 ### Windows
 
-```powershell
-# WSL2が必要
-# PowerShellを管理者として実行
-wsl --install
+Windowsでは、PowerShellまたはCMDのnative `podman.exe`からPodman machineへ接続する経路を標準とします。Podman v6.0以降の現行guideはWindows 11以降、hardware virtualization、およびWSL2またはHyper-V providerを前提とします。公式MSIのuser-scope installは管理者権限を必要としませんが、provider自体の有効化条件は別途満たす必要があります。
 
-# WSL2内でLinuxディストリビューションをインストール後、
-# 上記のLinux用手順に従ってインストール
+```powershell
+# 公式MSIを導入した新しいPowerShellで確認
+podman --version
+
+# default provider（現行WindowsではWSL）でmachineを作成して起動
+podman machine init --now
+
+# Windows host側CLI、Podman-managed guest、接続先を確認
+podman machine list
+podman machine inspect
+podman system connection list
+podman info --format json
 ```
+
+Hyper-Vを明示的に選択する場合は、Windows edition、Hyper-V Administrators group、provider準備を確認してから`podman machine init --provider hyperv`を使用します。WSL providerとHyper-V providerのmachineは同時に起動しません。WSLの有効化やHyper-V準備は[Podman for Windows](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman-for-windows.md)を正本とし、本書ではWindows機能の導入手順を重複掲載しません。
+
+#### WSL2 distribution内でLinux版Podmanを直接実行する経路（任意）
+
+既存のUbuntuなどのWSL2 distribution内でLinux版Podmanを直接実行する構成は、Windows host側のPodman machineとは別経路です。この場合、CLIとPodman engineは同じWSL distribution内で動作し、`podman machine init`やmachine用remote connectionは使用しません。
+
+```bash
+# 既存WSL2 distributionのLinux shell内で実行
+sudo apt update
+sudo apt install -y podman
+
+podman --version
+podman info --format json
+podman system connection list
+```
+
+`podman info --format json`の`serviceIsRemote`が`false`であることを確認します。rootless運用では通常のLinuxと同様に`/etc/subuid`、`/etc/subgid`、user namespace、storage driverを確認します。Windows側のPodman machineとdirect WSL2のimage、container、volume、connection設定は共有されない前提で管理してください。
+
+#### 経路の選択と切り分け
+
+| 経路 | CLIを実行する場所 | Linux実行環境 | CLIの接続先 | rootlessと状態 |
+|---|---|---|---|---|
+| macOS標準 | macOS terminalの`podman` | Podman-managed Linux VM | machineが登録するremote connection | guestはrootless既定。machine単位で状態を管理 |
+| Windows標準 | PowerShell / CMDの`podman.exe` | Podman-managed WSL distributionまたはHyper-V VM | machineが登録するremote connection | guestはrootless既定。rootfulとはstorageを分離 |
+| WSL2 direct（任意） | 既存WSL2 distributionのLinux shell | そのWSL2 distribution | local Podman（`serviceIsRemote: false`） | Linux側userのrootless設定とstorageを使用 |
+
+切り分け時は、まずCLIを実行しているshellを確認します。host側の標準経路では`podman machine list`、`podman machine inspect`、`podman system connection list`を確認します。WSL2 direct経路では`command -v podman`と`podman info --format json`を確認し、machine側のcontainerが見えないことを障害と誤認しないでください。
+
+- [Podman installation](https://podman.io/docs/installation)
+- [podman-machine](https://docs.podman.io/en/stable/markdown/podman-machine.1.html)
+- [podman-machine-inspect](https://docs.podman.io/en/stable/markdown/podman-machine-inspect.1.html)
+- [Podman for Windows](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman-for-windows.md)
 
 ## 2.3 初期設定
 

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -8,10 +8,10 @@ title: "第2章：Podmanのインストールと初期設定"
 
 ## 検証基準と環境
 
-- **platform導入手順**: Podman stable文書とv6.0.1（2026-07-08公開）で確認（2026-07-21）
-- **Linux実行例**: Ubuntu 24.04 / Podman 4.9.3で確認。distribution packageのversionはOS releaseごとに異なるため、固定値を期待せず`podman --version`で記録します。
-- **desktop前提**: macOS / Windowsではhost側CLIがPodman machine内のLinux Podmanへremote接続します。Windows向け現行公式guideはWindows 11以降を前提とします。
-- **rootless前提**: 一般userで実行する本章のLinux例とmachine guestはrootlessを基準にします。`sudo podman`やmachineをrootfulへ切り替えた場合は、storage、image、containerの表示範囲がrootless側と分かれることを確認します。
+- **プラットフォーム導入手順**: Podman stable文書とv6.0.1（2026-07-08公開）で確認（2026-07-21）
+- **Linux実行例**: Ubuntu 24.04 / Podman 4.9.3で確認。ディストリビューションが提供するパッケージのバージョンはOSリリースごとに異なるため、固定値を期待せず`podman --version`で記録します。
+- **デスクトップ前提**: macOS / Windowsではホスト側CLIがPodman machine内のLinux Podmanへリモート接続します。Windows向け現行公式ガイドはWindows 11以降を前提とします。
+- **rootless前提**: 一般ユーザーで実行する本章のLinux例とmachineのLinuxゲストはrootlessを基準にします。`sudo podman`やmachineをrootfulへ切り替えた場合は、storage、image、containerの表示範囲がrootless側と分かれることを確認します。
 
 ## 2.1 自動インストールスクリプト
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:security": "npm audit",
     "check:figure-index": "node scripts/check-figure-index.js",
     "check:podman-backends": "node scripts/check-podman-backend-contract.js && node scripts/check-podman-backend-contract-regression.js",
-    "test": "npm run check:metadata && npm run check:figure-index && npm run check:podman-backends && npm run build"
+    "check:podman-machine-paths": "node scripts/check-podman-machine-path-contract.js && node scripts/check-podman-machine-path-contract-regression.js",
+    "test": "npm run check:metadata && npm run check:figure-index && npm run check:podman-backends && npm run check:podman-machine-paths && npm run build"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0"

--- a/scripts/check-podman-machine-path-contract-regression.js
+++ b/scripts/check-podman-machine-path-contract-regression.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/* Regression fixtures for the Podman machine path contract. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { contracts, validateText } = require('./check-podman-machine-path-contract');
+
+const repoRoot = path.resolve(__dirname, '..');
+const baseline = Object.fromEntries(
+  Object.entries(contracts).map(([name, contract]) => [
+    name,
+    fs.readFileSync(path.join(repoRoot, contract.path), 'utf8'),
+  ])
+);
+
+const fixtures = [
+  [
+    'missing-standard-machine-label',
+    'chapter02',
+    baseline.chapter02.replace('Podman machine（標準経路）', 'Podman setup'),
+  ],
+  [
+    'missing-direct-wsl-separation',
+    'chapter02',
+    baseline.chapter02.replace(
+      'WSL2 distribution内でLinux版Podmanを直接実行する経路（任意）',
+      'Windows追加手順'
+    ),
+  ],
+  [
+    'missing-connection-checks',
+    'chapter02',
+    baseline.chapter02.replaceAll('podman system connection list', 'removed connection check'),
+  ],
+  ['legacy-wsl-only', 'chapter02', baseline.chapter02 + '\n# WSL2が必要\n'],
+  ['legacy-homebrew-default', 'chapter02', baseline.chapter02 + '\n# Homebrewを使用\n'],
+  [
+    'missing-remote-local-boundary',
+    'chapter02',
+    baseline.chapter02.replaceAll('serviceIsRemote', 'removedRemoteMarker'),
+  ],
+  [
+    'legacy-windows-comparison',
+    'chapter01',
+    baseline.chapter01 + '\n| **Windows対応** | △ WSL2経由 | ◎ ネイティブ | Windows中心→Docker |\n',
+  ],
+  [
+    'legacy-macos-comparison',
+    'chapter01',
+    baseline.chapter01 + '\n| **macOS対応** | △ VM経由 | ◎ Docker Desktop | macOS開発→Docker |\n',
+  ],
+];
+
+for (const [label, contractName, text] of fixtures) {
+  if (validateText(text, contractName, label).length === 0) {
+    throw new Error(`negative fixture was accepted: ${label}`);
+  }
+}
+
+for (const [name, text] of Object.entries(baseline)) {
+  const errors = validateText(text, name, `baseline-${name}`);
+  if (errors.length) throw new Error(`valid baseline was rejected: ${errors.join('; ')}`);
+}
+
+console.log(
+  `Podman machine path regression fixtures: OK (${fixtures.length} negative, ${Object.keys(baseline).length} positive)`
+);

--- a/scripts/check-podman-machine-path-contract.js
+++ b/scripts/check-podman-machine-path-contract.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/* Validate the macOS/Windows Podman machine and direct-WSL path contract. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+const contracts = {
+  chapter01: {
+    path: 'docs/chapters/chapter01/index.md',
+    required: [
+      'native CLI + Podman machine（WSL / Hyper-V guest）',
+      'native CLI + Podman machine（Linux VM）',
+      'どちらもLinux VMを使用',
+    ],
+  },
+  chapter02: {
+    path: 'docs/chapters/chapter02/index.md',
+    required: [
+      'Podman stable文書とv6.0.1',
+      'Windows 11以降',
+      'Podman machine（標準経路）',
+      'podman machine init --now',
+      'podman machine inspect',
+      'podman system connection list',
+      'serviceIsRemote',
+      'WSL2 distribution内でLinux版Podmanを直接実行する経路（任意）',
+      'machine側のcontainerが見えないことを障害と誤認しない',
+      'https://podman.io/docs/installation',
+      'https://docs.podman.io/en/stable/markdown/podman-machine.1.html',
+      'https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman-for-windows.md',
+    ],
+  },
+};
+
+const forbidden = {
+  chapter01: [
+    { label: 'legacy Windows WSL-only comparison', pattern: /Windows対応\*\*\s*\|\s*△\s*WSL2経由/ },
+    { label: 'legacy macOS generic-VM comparison', pattern: /macOS対応\*\*\s*\|\s*△\s*VM経由/ },
+  ],
+  chapter02: [
+    { label: 'WSL2 direct path presented as the only Windows prerequisite', pattern: /#\s*WSL2が必要/ },
+    { label: 'community Homebrew path presented as the default', pattern: /#\s*Homebrewを使用/ },
+    { label: 'old Windows direct-install continuation', pattern: /WSL2内でLinuxディストリビューションをインストール後/ },
+  ],
+};
+
+const minimumCounts = {
+  chapter02: [
+    { label: 'macOS and Windows machine initialization examples', marker: 'podman machine init --now', count: 2 },
+    { label: 'machine/direct connection checks', marker: 'podman system connection list', count: 3 },
+    { label: 'remote/local connection boundary explanations', marker: 'serviceIsRemote', count: 2 },
+  ],
+};
+
+function validateText(text, contractName, sourceLabel = contractName) {
+  const contract = contracts[contractName];
+  if (!contract) throw new Error(`unknown contract: ${contractName}`);
+  const errors = [];
+  for (const marker of contract.required) {
+    if (!text.includes(marker)) errors.push(`${sourceLabel}: missing required marker: ${marker}`);
+  }
+  for (const rule of forbidden[contractName] || []) {
+    if (rule.pattern.test(text)) errors.push(`${sourceLabel}: forbidden ${rule.label}`);
+  }
+  for (const rule of minimumCounts[contractName] || []) {
+    const actual = text.split(rule.marker).length - 1;
+    if (actual < rule.count) {
+      errors.push(`${sourceLabel}: ${rule.label} count ${actual} is below ${rule.count}`);
+    }
+  }
+  return errors;
+}
+
+function validateRepository() {
+  const errors = [];
+  for (const [name, contract] of Object.entries(contracts)) {
+    const file = path.join(repoRoot, contract.path);
+    if (!fs.existsSync(file)) {
+      errors.push(`${contract.path}: file is missing`);
+      continue;
+    }
+    errors.push(...validateText(fs.readFileSync(file, 'utf8'), name, contract.path));
+  }
+  return errors;
+}
+
+function main() {
+  const errors = validateRepository();
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log('Podman machine path contract: OK (macOS/Windows machine + direct WSL2)');
+}
+
+if (require.main === module) main();
+
+module.exports = { contracts, validateRepository, validateText };


### PR DESCRIPTION
## 変更概要

- macOS / Windowsの標準導入経路を、host側CLI + Podman machine + Linux guest + remote connectionとして明示
- WindowsのPodman-managed WSL / Hyper-V machineと、既存WSL2 distribution内でLinux版Podmanを直接実行する任意経路を分離
- CLI実行場所、Linux実行環境、接続先、rootless / rootful、storage分離を比較表と切り分け手順で整理
- macOSの公式installer推奨、Windows 11+ / WSLまたはHyper-V providerの現行前提へ更新
- Chapter 1のWindows / macOS比較行を同じ用語へ同期
- 旧WSL-only標準手順の再混入を拒否するQA contractと8 negative / 2 positive fixtureを追加し、PR / mainのBook QAとbuild workflowへ統合

## 一次情報監査

- Podman公式latest release v6.0.1（2026-07-08）
- Podman installation
- podman-machine / machine inspect / machine init
- Podman for Windows（v6.0+、Windows 11+、WSL / Hyper-V provider、rootless既定、host remote接続）

## 検証

- `npm ci` / full `npm audit`: vulnerability 0
- `npm test`: metadata 20 routes、figure index 6 figures、backend contract、machine path contract、build成功
- machine path regression: 8 negative / 2 positive
- pinned book-formatter `69eb5c12...`: Unicode / Textlint / Links / Layout / Structure error 0
- Bundler / Jekyll build成功、Chapter 1 / 2の生成HTML marker確認
- Windows 11 Pro + WSL2 hostで公式v6.0.1 Windows portable artifactのSHA-256一致、`podman version 6.0.1`、`machine init --help`の`--now` / `--provider`、machine subcommandを確認
- 同hostのUbuntu 24.04 / Podman 4.9.3 rootless direct pathで`serviceIsRemote=false`、connection 0、overlay / Netavarkを確認
- 公式URL 4件HTTP 200

## 環境境界

Windows host側にPodmanは事前installされていません。disposable machineの実init / startはWindowsのWSL registrationを変更するため、workspace外のsystem stateを変更しない制約に従い実行していません。本文のmachine lifecycleとoptionは公式v6.0.1 native binaryおよび一次文書で照合しています。

## Scope

- #216のDocker rootless比較、#207の章構成、#189の画像、Chapter 6 / 15のlegacy CNI記述には変更なし

Closes #215
