### PR TITLE
docs: Chapter 6/15のlegacy CNI手順をNetavarkへ更新

### DIFF
--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -310,33 +310,33 @@ volumes:
 
 #### 6.3.1 ファイアウォール統合
 
+以下はPodman v6.0.1を基準に2026-07-21に確認した手順です。現行PodmanはNetavarkをnetwork backendとして使用し、managed bridgeの作成時にmasqueradeとport forwardingに必要なhost firewall ruleを管理します。CNIの`.conflist`を作成したり、CNI firewall pluginを追加したりしません。
+
 ```bash
-# CNIファイアウォールプラグイン設定
-cat > /etc/cni/net.d/87-podman-bridge.conflist << EOF
-{
-  "cniVersion": "0.4.0",
-  "name": "podman",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "cni-podman0",
-      "isGateway": true,
-      "ipMasq": true,
-      "ipam": {
-        "type": "host-local",
-        "routes": [{"dst": "0.0.0.0/0"}],
-        "ranges": [[{"subnet": "10.88.0.0/16"}]]
-      }
-    },
-    {
-      "type": "firewall",
-      "backend": "iptables",
-      "ingressPolicy": "same-bridge"
-    }
-  ]
-}
-EOF
+# backendとDNS componentを公開APIで確認
+podman info --format json |
+  jq '{backend: .host.networkBackend, dns: .host.networkBackendInfo.dns.version}'
+
+# managed bridgeを作成。NetavarkがNATとport forwardingのruleを管理する
+podman network create \
+  --driver bridge \
+  --subnet 10.89.0.0/24 \
+  application-net
+
+# generated fileを直接編集せず、公開CLIで設定を確認
+podman network inspect application-net |
+  jq '.[0] | {name, driver, network_interface, subnets, dns_enabled}'
+
+# host運用でfirewalldをreloadした後、rootful containerのruleを復旧
+sudo podman network reload --all
 ```
+
+`podman network reload`は、firewall ruleが削除されたrootful containerのnetwork設定を復旧するcommandです。通常のnetwork作成ごとに実行するものではなく、rootless環境やPodman remote clientでは同じ前提になりません。host firewall policyを独自管理する場合も、generated Netavark ruleを直接書き換えず、変更責任と復旧手順を運用設計に記録します。
+
+- [Podman 6.0.0 release notes（CNI networking削除）](https://github.com/containers/podman/releases/tag/v6.0.0)
+- [Podman v6.0.1 release notes（確認対象version）](https://github.com/containers/podman/releases/tag/v6.0.1)
+- [`podman network create`（managed bridgeとfirewallの責務）](https://docs.podman.io/en/stable/markdown/podman-network-create.1.html)
+- [`podman network reload`（firewall reload後の復旧）](https://docs.podman.io/en/stable/markdown/podman-network-reload.1.html)
 
 #### 6.3.2 ネットワーク分離
 
@@ -400,7 +400,9 @@ podman run \
 
 ```bash
 # ネットワーク診断
-podman network inspect podman | jq '.[] | .plugins'
+podman info --format json | jq '.host | {networkBackend, networkBackendInfo}'
+podman network inspect podman |
+  jq '.[0] | {name, driver, network_interface, subnets, dns_enabled}'
 
 # ポート確認
 podman port mycontainer

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -243,13 +243,17 @@ if command -v iptables >/dev/null 2>&1; then
     sudo iptables -t nat -L POSTROUTING -n | grep -E "MASQUERADE|podman"
 fi
 
-# 5. CNIプラグイン確認
-echo -e "\nCNI configuration:"
-if [ -d /etc/cni/net.d ]; then
-    ls -la /etc/cni/net.d/
-    cat /etc/cni/net.d/87-podman*.conflist 2>/dev/null | jq '.plugins[].type' | sort | uniq
-fi
+# 5. Netavark backendとnetwork定義の確認
+echo -e "\nNetwork backend:"
+podman info --format json |
+    jq '.host | {networkBackend, networkBackendInfo}'
+
+echo -e "\nDefined networks:"
+podman network ls --format json |
+    jq '.[] | {name, driver, network_interface, dns_enabled, subnets}'
 ```
+
+この診断はPodman v6.0.1を基準に2026-07-21に確認しています。現行環境ではCNI directoryやpluginの有無を正常性条件にせず、Netavark backend、aardvark-dns情報、`podman network`の公開出力を確認します。rootful containerの通信がfirewalld reload後に失われた場合は、[`podman network reload`](https://docs.podman.io/en/stable/markdown/podman-network-reload.1.html)で当該containerまたは全containerのruleを復旧します。
 
 **一般的なネットワーク問題の解決**
 
@@ -809,20 +813,32 @@ check_podman_config() {
 check_network() {
     echo -n "Checking network configuration... "
     
-    # CNIプラグイン
-    if [ -d /usr/libexec/cni ] || [ -d /opt/cni/bin ]; then
-        DIAGNOSTICS["cni"]="OK"
+    # 現行backendとDNS component
+    NETWORK_BACKEND=$(podman info --format json | jq -r '.host.networkBackend // empty')
+    DNS_BACKEND=$(podman info --format json | jq -r '.host.networkBackendInfo.dns.version // empty')
+    if [ "$NETWORK_BACKEND" = "netavark" ]; then
+        DIAGNOSTICS["network_backend"]="OK: netavark"
     else
-        DIAGNOSTICS["cni"]="FAIL: CNI plugins not found"
+        DIAGNOSTICS["network_backend"]="FAIL: Expected netavark, got ${NETWORK_BACKEND:-unknown}"
+    fi
+
+    if [ -n "$DNS_BACKEND" ]; then
+        DIAGNOSTICS["network_dns"]="OK: $DNS_BACKEND"
+    else
+        DIAGNOSTICS["network_dns"]="WARN: DNS backend information is unavailable"
+    fi
+
+    if podman network ls --format json | jq -e 'type == "array"' >/dev/null; then
+        DIAGNOSTICS["network_list"]="OK"
+    else
+        DIAGNOSTICS["network_list"]="FAIL: podman network ls failed"
     fi
     
     # ファイアウォール
-    if command -v firewall-cmd >/dev/null 2>&1; then
-        if firewall-cmd --get-active-zones | grep -q "trusted"; then
-            DIAGNOSTICS["firewall"]="OK"
-        else
-            DIAGNOSTICS["firewall"]="WARN: Firewall may block container traffic"
-        fi
+    if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+        DIAGNOSTICS["firewall"]="OK: firewalld active; reload後はrootful networkを再確認"
+    else
+        DIAGNOSTICS["firewall"]="OK: active firewalld not detected"
     fi
     
     echo "Done"
@@ -841,10 +857,6 @@ auto_fix() {
                     echo "Enabling user namespaces..."
                     echo "user.max_user_namespaces=28633" | sudo tee /etc/sysctl.d/userns.conf
                     sudo sysctl -p /etc/sysctl.d/userns.conf
-                    ;;
-                "cni")
-                    echo "Installing CNI plugins..."
-                    # プラットフォーム依存のインストールコマンド
                     ;;
             esac
         fi

--- a/scripts/check-podman-backend-contract-regression.js
+++ b/scripts/check-podman-backend-contract-regression.js
@@ -28,6 +28,19 @@ const fixtures = [
     'chapter03',
     baseline.chapter03.replaceAll('podman network inspect', 'removed network inspection command'),
   ],
+  ['chapter06-legacy-cni-conflist', 'chapter06', baseline.chapter06 + '\n/etc/cni/net.d/87-podman.conflist\n'],
+  ['chapter15-cni-plugin-directory', 'chapter15', baseline.chapter15 + '\n/usr/libexec/cni\n'],
+  ['chapter15-cni-install-repair', 'chapter15', baseline.chapter15 + '\nInstalling CNI plugins...\n'],
+  [
+    'chapter06-missing-network-reload',
+    'chapter06',
+    baseline.chapter06.replaceAll('sudo podman network reload --all', 'removed network reload command'),
+  ],
+  [
+    'chapter15-missing-backend-diagnostic',
+    'chapter15',
+    baseline.chapter15.replaceAll('DIAGNOSTICS["network_backend"]="OK: netavark"', 'removed backend result'),
+  ],
 ];
 
 for (const [label, contractName, text] of fixtures) {

--- a/scripts/check-podman-backend-contract.js
+++ b/scripts/check-podman-backend-contract.js
@@ -35,6 +35,35 @@ const contracts = {
       'https://github.com/podman-container-tools/container-libs/blob/main/storage/docs/containers-storage.conf.5.md',
     ],
   },
+  chapter06: {
+    path: 'docs/chapters/chapter06/index.md',
+    required: [
+      '以下はPodman v6.0.1を基準に2026-07-21に確認した手順です',
+      'podman info --format json',
+      'podman network create',
+      '--driver bridge',
+      'podman network inspect application-net',
+      'sudo podman network reload --all',
+      'https://github.com/containers/podman/releases/tag/v6.0.0',
+      'https://github.com/containers/podman/releases/tag/v6.0.1',
+      'https://docs.podman.io/en/stable/markdown/podman-network-create.1.html',
+      'https://docs.podman.io/en/stable/markdown/podman-network-reload.1.html',
+    ],
+  },
+  chapter15: {
+    path: 'docs/chapters/chapter15/index.md',
+    required: [
+      '# 5. Netavark backendとnetwork定義の確認',
+      'podman info --format json',
+      'podman network ls --format json',
+      'NETWORK_BACKEND=$(podman info --format json',
+      'DNS_BACKEND=$(podman info --format json',
+      'DIAGNOSTICS["network_backend"]="OK: netavark"',
+      'https://docs.podman.io/en/stable/markdown/podman-network-reload.1.html',
+      '現行環境ではCNI directoryやpluginの有無を正常性条件にせず',
+      'この診断はPodman v6.0.1を基準に2026-07-21に確認しています',
+    ],
+  },
 };
 
 const forbidden = [
@@ -46,6 +75,9 @@ const forbidden = [
   { label: 'active CNI backend setting', pattern: /network_backend\s*=\s*["']cni["']/i },
   { label: 'legacy rootless CNI config path', pattern: /~\/\.config\/cni\/net\.d/i },
   { label: 'legacy rootful CNI config path', pattern: /\/etc\/cni\/net\.d/i },
+  { label: 'legacy CNI plugin directory', pattern: /\/(?:usr\/libexec|opt)\/cni(?:\/bin)?/i },
+  { label: 'CNI plugin installation repair', pattern: /Install(?:ing)?\s+CNI\s+plugins?/i },
+  { label: 'CNI diagnostic result key', pattern: /DIAGNOSTICS\[["']cni["']\]/i },
   { label: 'active CNI plugin section', pattern: /^#{2,6}\s+.*CNIプラグイン/im },
   { label: 'active CNI exercise', pattern: /カスタムCNI設定/ },
   { label: 'active rootless CNI procedure', pattern: /Rootless\s*CNI/ },


### PR DESCRIPTION
## Summary

- Chapter 6のCNI conflist/firewall plugin作成例を、Netavark managed bridgeと公開`podman network` CLIへ置換
- Chapter 15のCNI plugin診断・install提案を、Netavark/aardvark-dns/network list診断へ置換
- 既存Podman backend QA contractをChapter 6/15へ拡張し、legacy CNI再混入を13 negative / 4 positive fixtureで検知

## Current-version basis

- 確認日: 2026-07-21
- 最新release: Podman v6.0.1（GitHub APIで確認）
- CNI removal boundary: Podman v6.0.0 release notes
- CLI contract: stable `podman info`, `podman network create`, `podman network reload`
- local CLI shape check: Podman 4.9.3 / Netavark / aardvark-dns 1.4.0。v6 runtime自体の実行は行わず、v6は公式一次情報で確認

## Verification

- `npm audit --audit-level=low`: 0 vulnerabilities
- `npm test`: metadata、figure index、全4 backend contracts、machine paths、Docker rootless、Node build成功
- Podman backend regression: 13 negative / 4 positive
- pinned book-formatter `69eb5c12...`: Unicode / Textlint / Links / Layout / Structure error 0
- Bundler/Jekyll build成功。Chapter 6/15生成HTMLのNetavark markerとlegacy CNI path不在を確認
- 一次情報URL 4件HTTP 200
- `git diff --check`成功

## Scope

- escaped Go templateは#221の別PRで処理
- Chapter 3のhistorical CNI migration説明は維持

Closes #220
