### PR TITLE
docs: 公開commandのliteral templateを正しく保持する

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Docker rootless comparison contract check
         run: npm run check:docker-rootless-comparison
 
+      - name: Literal template source contract check
+        run: npm run check:literal-templates
+
       - name: Checkout book-formatter (pinned)
         uses: actions/checkout@v6
         with:
@@ -115,6 +118,9 @@ jobs:
         with:
           source: ./${{ steps.scan.outputs.dir }}
           destination: ./_site
+
+      - name: Literal template rendered-site check
+        run: node scripts/check-literal-template-rendering.js --site _site
 
       - name: Smoke check built site (top + navigation + assets)
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,9 @@ jobs:
 
     - name: Docker rootless comparison contract check
       run: npm run check:docker-rootless-comparison
+
+    - name: Literal template source contract check
+      run: npm run check:literal-templates
         
     - name: Build book
       run: npm run build

--- a/docs/additional/enterprise-requirements.md
+++ b/docs/additional/enterprise-requirements.md
@@ -105,6 +105,7 @@ ENV OPENSSL_FORCE_FIPS_MODE=1
 ### 3. セキュリティスキャン統合
 
 #### Trivyによる脆弱性スキャン
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # security-scan.sh - コンテナイメージのセキュリティスキャン
@@ -136,10 +137,11 @@ scan_image() {
 }
 
 # CI/CDパイプラインでの使用例
-for image in $(podman images --format "\{\{.Repository\}\}:\{\{.Tag\}\}" | grep -v "<none>"); do
+for image in $(podman images --format "{{.Repository}}:{{.Tag}}" | grep -v "<none>"); do
     scan_image $image || exit 1
 done
 ```
+<!-- {% endraw %} -->
 
 ## 監査とコンプライアンス
 
@@ -333,6 +335,7 @@ chmod +x /usr/local/bin/check-podman-health.sh
 
 ### 2. バックアップとリストア
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # backup-restore.sh - Podman環境のバックアップとリストア
@@ -348,7 +351,7 @@ backup_podman_environment() {
     
     # 2. イメージのエクスポート
     mkdir -p $backup_dir/images
-    for image in $(podman images --format "\{\{.Repository\}\}:\{\{.Tag\}\}" | grep -v "<none>"); do
+    for image in $(podman images --format "{{.Repository}}:{{.Tag}}" | grep -v "<none>"); do
         safe_name=$(echo $image | tr '/:' '_')
         podman save -o $backup_dir/images/${safe_name}.tar $image
     done
@@ -356,7 +359,7 @@ backup_podman_environment() {
     # 3. ボリュームのバックアップ
     mkdir -p $backup_dir/volumes
     for volume in $(podman volume ls -q); do
-        volume_path=$(podman volume inspect $volume --format '\{\{.Mountpoint\}\}')
+        volume_path=$(podman volume inspect $volume --format '{{.Mountpoint}}')
         tar czf $backup_dir/volumes/${volume}.tar.gz -C $(dirname $volume_path) $(basename $volume_path)
     done
     
@@ -391,7 +394,7 @@ restore_podman_environment() {
     for volume_tar in $backup_dir/volumes/*.tar.gz; do
         volume_name=$(basename $volume_tar .tar.gz)
         podman volume create $volume_name
-        volume_path=$(podman volume inspect $volume_name --format '\{\{.Mountpoint\}\}')
+        volume_path=$(podman volume inspect $volume_name --format '{{.Mountpoint}}')
         tar xzf $volume_tar -C $(dirname $volume_path)
     done
     
@@ -416,6 +419,7 @@ restore_podman_environment() {
     echo "リストア完了"
 }
 ```
+<!-- {% endraw %} -->
 
 ## パフォーマンスとスケーラビリティ
 

--- a/docs/additional/migration-guide.md
+++ b/docs/additional/migration-guide.md
@@ -20,6 +20,7 @@ title: "Docker→Podman包括的移行ガイドライン"
 ### Phase 0: 現状分析（1週間）
 
 #### インベントリ作成
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # docker-inventory.sh - Docker環境の棚卸しスクリプト
@@ -32,11 +33,11 @@ docker --version
 
 echo ""
 echo "2. 実行中のコンテナ:"
-docker ps --format "table \{\{.Names\}\}\t\{\{.Image\}\}\t\{\{.Status\}\}\t\{\{.Ports\}\}"
+docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"
 
 echo ""
 echo "3. イメージ一覧:"
-docker images --format "table \{\{.Repository\}\}:\{\{.Tag\}\}\t\{\{.Size\}\}"
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}"
 
 echo ""
 echo "4. ボリューム一覧:"
@@ -54,8 +55,10 @@ echo ""
 echo "7. Dockerfile一覧:"
 find . -name "Dockerfile*" -type f 2>/dev/null | head -20
 ```
+<!-- {% endraw %} -->
 
 #### 互換性評価
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # compatibility-check.sh - Podman互換性チェック
@@ -74,11 +77,12 @@ echo -n "[ ] Docker Compose v1（docker-compose）の残存: "
 command -v docker-compose >/dev/null 2>&1 && echo "[WARN] 検出（legacy）" || echo "[OK] 未検出"
 
 echo -n "[ ] 特権コンテナの使用: "
-docker ps --format '\{\{.Names\}\}' | xargs -I {} docker inspect {} | grep -q '"Privileged": true' && echo "[WARN] 使用中" || echo "[OK] 未使用"
+docker ps --format '{{.Names}}' | xargs -I {} docker inspect {} | grep -q '"Privileged": true' && echo "[WARN] 使用中" || echo "[OK] 未使用"
 
 echo -n "[ ] カスタムDockerネットワーク: "
-docker network ls --format '\{\{.Name\}\}' | grep -v -E 'bridge|host|none' | wc -l | xargs -I {} test {} -gt 0 && echo "[WARN] 使用中（要確認）" || echo "[OK] 標準のみ"
+docker network ls --format '{{.Name}}' | grep -v -E 'bridge|host|none' | wc -l | xargs -I {} test {} -gt 0 && echo "[WARN] 使用中（要確認）" || echo "[OK] 標準のみ"
 ```
+<!-- {% endraw %} -->
 
 ## Phase 1: 互換性確認と準備（1〜2週間）
 
@@ -145,6 +149,7 @@ volumes:
 ```
 
 ### イメージ移行スクリプト
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # migrate-images.sh - DockerイメージのPodmanへの移行
@@ -170,12 +175,14 @@ migrate_image() {
 }
 
 # 全イメージの移行
-docker images --format '\{\{.Repository\}\}:\{\{.Tag\}\}' | grep -v '<none>' | while read image; do
+docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>' | while read image; do
     migrate_image $image
 done
 ```
+<!-- {% endraw %} -->
 
 ### ボリュームデータの移行
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # migrate-volumes.sh - Dockerボリュームの移行
@@ -184,13 +191,13 @@ migrate_volume() {
     local vol_name=$1
     
     # Dockerボリュームのパスを取得
-    docker_path=$(docker volume inspect $vol_name --format '\{\{.Mountpoint\}\}')
+    docker_path=$(docker volume inspect $vol_name --format '{{.Mountpoint}}')
     
     # Podmanボリューム作成
     podman volume create $vol_name
     
     # Podmanボリュームのパスを取得
-    podman_path=$(podman volume inspect $vol_name --format '\{\{.Mountpoint\}\}')
+    podman_path=$(podman volume inspect $vol_name --format '{{.Mountpoint}}')
     
     # データコピー（root権限が必要な場合あり）
     echo "コピー中: $vol_name"
@@ -204,6 +211,7 @@ docker volume ls -q | while read volume; do
     migrate_volume $volume
 done
 ```
+<!-- {% endraw %} -->
 
 ## Phase 2: パイロット導入（2〜4週間）
 

--- a/docs/additional/troubleshooting-guide.md
+++ b/docs/additional/troubleshooting-guide.md
@@ -31,6 +31,7 @@ graph TD
 
 ### 基本診断コマンド
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # podman-diagnose.sh - Podman環境の基本診断
@@ -61,7 +62,7 @@ podman info --format json | jq '{
 
 # 3. 実行中のコンテナ
 echo -e "\n[INFO] 実行中のコンテナ:"
-podman ps --format "table \{\{.Names\}\}\t\{\{.Status\}\}\t\{\{.State\}\}"
+podman ps --format "table {{.Names}}\t{{.Status}}\t{{.State}}"
 
 # 4. システムリソース
 echo -e "\n[INFO] システムリソース:"
@@ -75,6 +76,7 @@ podman network ls
 echo -e "\n[INFO] 最近のイベント (エラーのみ):"
 podman events --since 1h --filter event=died --format json | jq '.'
 ```
+<!-- {% endraw %} -->
 
 ## 起動エラーの解決
 
@@ -241,6 +243,7 @@ Error: writing blob: write /var/tmp/storage123/layer.tar: no space left on devic
 ```
 
 #### 診断と解決
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # fix-storage-issues.sh
@@ -257,10 +260,10 @@ podman system df -v
 
 # 3. 大きなイメージ/コンテナの特定
 echo -e "\n大きなイメージ (上位10):"
-podman images --format "table \{\{.Repository\}\}:\{\{.Tag\}\}\t\{\{.Size\}\}" | sort -k2 -hr | head -10
+podman images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" | sort -k2 -hr | head -10
 
 echo -e "\n大きなコンテナ (上位10):"
-podman ps -a --format "table \{\{.Names\}\}\t\{\{.Size\}\}" | sort -k2 -hr | head -10
+podman ps -a --format "table {{.Names}}\t{{.Size}}" | sort -k2 -hr | head -10
 
 # 4. クリーンアップ提案
 echo -e "\nクリーンアップオプション:"
@@ -317,6 +320,7 @@ if [ "${PRUNE_VOLUMES:-NO}" = "YES" ]; then
 fi
 EOF
 ```
+<!-- {% endraw %} -->
 
 ## ネットワーク問題の解決
 
@@ -456,6 +460,7 @@ EOF
 ### 1. コンテナの起動が遅い
 
 #### 診断と解決
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # analyze-slow-startup.sh
@@ -476,7 +481,7 @@ podman --log-level=debug run --rm $image true 2>&1 | grep -E "time=|duration=" |
 
 # 3. ストレージドライバーの確認
 echo -e "\nストレージドライバー:"
-storage_driver=$(podman info --format '\{\{.Store.GraphDriverName\}\}')
+storage_driver=$(podman info --format '{{.Store.GraphDriverName}}')
 echo "現在のドライバー: $storage_driver"
 
 if [ "$storage_driver" != "overlay" ]; then
@@ -486,7 +491,7 @@ fi
 
 # 4. イメージレイヤーの分析
 echo -e "\nイメージレイヤー分析:"
-podman history --format "table \{\{.ID\}\}\t\{\{.Size\}\}\t\{\{.CreatedBy\}\}" $image | head -10
+podman history --format "table {{.ID}}\t{{.Size}}\t{{.CreatedBy}}" $image | head -10
 
 # 5. 最適化の提案
 echo -e "\nパフォーマンス改善方法:"
@@ -507,10 +512,12 @@ cat << EOF
    - cgroup v2の使用
 EOF
 ```
+<!-- {% endraw %} -->
 
 ### 2. メモリ使用量が多い
 
 #### 診断と解決
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # analyze-memory-usage.sh
@@ -523,11 +530,11 @@ free -h
 
 # 2. コンテナごとのメモリ使用量
 echo -e "\nコンテナメモリ使用量:"
-podman stats --no-stream --format "table \{\{.Name\}\}\t\{\{.MemUsage\}\}\t\{\{.MemPerc\}\}\t\{\{.PIDs\}\}"
+podman stats --no-stream --format "table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.PIDs}}"
 
 # 3. 詳細なメモリ分析
 echo -e "\nメモリ詳細分析:"
-for container in $(podman ps --format "\{\{.Names\}\}"); do
+for container in $(podman ps --format "{{.Names}}"); do
     echo -e "\n--- $container ---"
     
     # cgroupメモリ情報
@@ -555,7 +562,7 @@ duration=${2:-60}
 echo "メモリ使用量を${duration}秒間監視..."
 
 for i in $(seq 1 $duration); do
-    mem=$(podman stats --no-stream --format "\{\{.MemUsage\}\}" $container | cut -d'/' -f1)
+    mem=$(podman stats --no-stream --format "{{.MemUsage}}" $container | cut -d'/' -f1)
     echo "$(date +%H:%M:%S) - $mem"
     sleep 1
 done | tee memory-trend.log
@@ -636,6 +643,7 @@ echo "1. メモリ制限の設定: podman run -m 512m"
 echo "2. スワップ制限: podman run -m 512m --memory-swap 512m"
 echo "3. OOMキラーの調整: podman run --oom-kill-disable=false"
 ```
+<!-- {% endraw %} -->
 
 ## 高度なトラブルシューティング
 

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -170,9 +170,10 @@ $ podman info --format json | jq '{
 
 ### network backendと設定の確認
 
+<!-- {% raw %} -->
 ```bash
 # 現在のbackendを確認。現行Podmanの通常buildではNetavark
-{% raw %}$ podman info --format '{{.Host.NetworkBackend}}'{% endraw %}
+$ podman info --format '{{.Host.NetworkBackend}}'
 netavark
 
 # 公開CLIでnetworkを作成
@@ -186,6 +187,7 @@ $ podman network inspect custom-net | jq '.[0] | {
     name, driver, network_interface, subnets, dns_enabled
   }'
 ```
+<!-- {% endraw %} -->
 
 Netavarkのnetwork config directoryは、rootfulでは`/etc/containers/networks`、rootlessでは`$graphroot/networks`です。`graphroot`の既定値は`$HOME/.local/share/containers/storage`ですが、固定pathを仮定せず`podman info`で確認します。generated JSONは内部実装として扱い、作成・変更・確認には`podman network` commandを使用します。
 

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -258,6 +258,7 @@ podman export mycontainer > container-backup.tar
 
 #### 4.4.1 ログ管理
 
+<!-- {% raw %} -->
 ```bash
 # ログ表示
 podman logs mycontainer
@@ -278,12 +279,14 @@ podman logs --since 2024-01-01T00:00:00 mycontainer
 podman run -d \
   --name logged-container \
   --log-driver journald \
-  --log-opt tag="\{\{.Name\}\}" \
+  --log-opt tag="{{.Name}}" \
   nginx:alpine
 ```
+<!-- {% endraw %} -->
 
 #### 4.4.2 リソースモニタリング
 
+<!-- {% raw %} -->
 ```bash
 # リアルタイム統計
 podman stats
@@ -295,7 +298,7 @@ podman stats mycontainer
 podman stats --no-stream
 
 # フォーマット指定
-podman stats --format "table \{\{.Container\}\}\t\{\{.CPUPerc\}\}\t\{\{.MemUsage\}\}"
+podman stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
 # プロセス一覧
 podman top mycontainer
@@ -303,6 +306,7 @@ podman top mycontainer
 # カスタムフォーマット
 podman top mycontainer pid,user,args
 ```
+<!-- {% endraw %} -->
 
 ### 4.5 トラブルシューティング
 

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -362,6 +362,7 @@ sudo podman run \
 
 #### 8.6.1 CIS Dockerベンチマーク準拠
 
+<!-- {% raw %} -->
 ```bash
 # 監査スクリプト
 cat > audit-containers.sh << 'EOF'
@@ -371,7 +372,7 @@ echo "=== Container Security Audit ==="
 
 # 実行中のコンテナ確認
 echo -e "\n[Running Containers]"
-podman ps --format "table \{\{.Names\}\}\t\{\{.Status\}\}\t\{\{.Ports\}\}"
+podman ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
 
 # 特権コンテナの確認
 echo -e "\n[Privileged Containers]"
@@ -396,6 +397,7 @@ EOF
 
 chmod +x audit-containers.sh
 ```
+<!-- {% endraw %} -->
 
 #### 8.6.2 セキュリティポリシーの実装
 

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -257,12 +257,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 
 インシデント対応、パフォーマンス分析、コンプライアンス対応のすべてがログに依存します。
 
+<!-- {% raw %} -->
 ```bash
 # journaldログドライバー設定 - なぜjournaldか
 podman run -d \
   --name app \
   --log-driver=journald \
-  --log-opt tag="\{\{.Name\}\}/\{\{.ID\}\}" \  # 識別しやすいタグ
+  --log-opt tag="{{.Name}}/{{.ID}}" \  # 識別しやすいタグ
   myapp:latest
 
 # journaldの利点：
@@ -291,6 +292,7 @@ podman run -d \
   --volume /run/systemd/journal:/run/systemd/journal:ro \
   fluent/fluentd:edge
 ```
+<!-- {% endraw %} -->
 
 ### 9.3 自動アップデート
 
@@ -328,13 +330,14 @@ EOF
 
 #### 9.3.2 カスタム更新戦略
 
+<!-- {% raw %} -->
 ```bash
 # update-strategy.sh
 #!/bin/bash
 
 SERVICE_NAME="container-myapp.service"
 NEW_IMAGE="myapp:new"
-OLD_IMAGE=$(podman inspect myapp --format '\{\{.ImageName\}\}')
+OLD_IMAGE=$(podman inspect myapp --format '{{.ImageName}}')
 
 # ヘルスチェック関数
 health_check() {
@@ -371,6 +374,7 @@ else
     exit 1
 fi
 ```
+<!-- {% endraw %} -->
 
 ### 9.4 バックアップとリストア
 
@@ -503,6 +507,7 @@ podman run -d \
 
 #### 9.5.2 アラート設定
 
+<!-- {% raw %} -->
 ```yaml
 # alerting-rules.yml
 groups:
@@ -515,7 +520,7 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Container \{\{ $labels.name \}\} is down"
+          summary: "Container {{ $labels.name }} is down"
           
       - alert: HighMemoryUsage
         expr: container_memory_usage_bytes / container_spec_memory_limit_bytes > 0.9
@@ -523,7 +528,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "Container \{\{ $labels.name \}\} memory usage is above 90%"
+          summary: "Container {{ $labels.name }} memory usage is above 90%"
           
       - alert: HighCPUUsage
         expr: rate(container_cpu_usage_seconds_total[5m]) > 0.9
@@ -531,8 +536,9 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "Container \{\{ $labels.name \}\} CPU usage is above 90%"
+          summary: "Container {{ $labels.name }} CPU usage is above 90%"
 ```
+<!-- {% endraw %} -->
 
 ### 9.6 パフォーマンスチューニング
 

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -249,6 +249,7 @@ GitHub Actionsは、以下の理由で多くの開発チームに選ばれてい
 
 **実践的なワークフローとその解説**
 
+<!-- {% raw %} -->
 ```yaml
 # .github/workflows/ci-cd.yml
 name: Build and Deploy
@@ -352,6 +353,7 @@ jobs:
           # ロールアウト待機（タイムアウト付き）
           kubectl rollout status deployment/app --timeout=300s
 ```
+<!-- {% endraw %} -->
 
 **このワークフローが実現する価値**
 
@@ -710,6 +712,7 @@ describe('E2E Tests', () => {
 - 即座のロールバック可能
 - 本番環境での検証
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # blue-green-deploy.sh
@@ -724,7 +727,7 @@ NEW_VERSION=$1
 # - 視覚的な状態管理
 
 # 現在の環境を確認
-CURRENT_ENV=$(podman ps --filter "label=app=$APP_NAME" --format "\{\{.Labels.environment\}\}")
+CURRENT_ENV=$(podman ps --filter "label=app=$APP_NAME" --format "{{.Labels.environment}}")
 if [ "$CURRENT_ENV" = "blue" ]; then
     NEW_ENV="green"
 else
@@ -760,7 +763,7 @@ done
 
 # スモークテスト - 基本機能の確認
 echo "Running smoke tests..."
-CONTAINER_IP=$(podman inspect ${APP_NAME}-${NEW_ENV} --format '\{\{.NetworkSettings.IPAddress\}\}')
+CONTAINER_IP=$(podman inspect ${APP_NAME}-${NEW_ENV} --format '{{.NetworkSettings.IPAddress}}')
 ./smoke-tests.sh $CONTAINER_IP || {
     echo "Smoke tests failed"
     podman stop ${APP_NAME}-${NEW_ENV}
@@ -798,6 +801,7 @@ podman rm ${APP_NAME}-${CURRENT_ENV}
 
 echo "Deployment completed successfully"
 ```
+<!-- {% endraw %} -->
 
 #### 10.6.2 Canary Deployment
 
@@ -865,6 +869,7 @@ data:
 
 **カナリーデプロイメントの自動化**
 
+<!-- {% raw %} -->
 ```python
 # canary-controller.py
 import time
@@ -885,13 +890,13 @@ class CanaryController:
         - ユーザー影響の定量化
         - 自動判断の基準
         """
-        query = f'rate(http_requests_total\{\{app="{self.app_name}",version="{version}",status=~"5.."\}\}[5m])'
+        query = f'rate(http_requests_total{{app="{self.app_name}",version="{version}",status=~"5.."}}[5m])'
         response = requests.get(f'{self.prometheus_url}/api/v1/query', params={'query': query})
         # ... パース処理
         
     def get_latency(self, version):
         """レイテンシを取得"""
-        query = f'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket\{\{app="{self.app_name}",version="{version}"\}\}[5m]))'
+        query = f'histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{{app="{self.app_name}",version="{version}"}}[5m]))'
         # ... 
         
     def adjust_traffic(self, new_weight):
@@ -904,10 +909,10 @@ class CanaryController:
         """
         # Nginxの設定を更新
         config = f"""
-        upstream myapp \{\{
+        upstream myapp {{
             server myapp-stable weight={int((1-new_weight)*10)};
             server myapp-canary weight={int(new_weight*10)};
-        \}\}
+        }}
         """
         # ... 設定適用
         
@@ -941,6 +946,7 @@ class CanaryController:
         print("Canary deployment successful")
         return True
 ```
+<!-- {% endraw %} -->
 
 ### 演習問題
 

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -28,16 +28,18 @@ title: "第12章：パフォーマンスチューニング"
 「測定できないものは改善できない」という原則に基づき、適切なメトリクス収集は最適化の第一歩です。
 
 **基本的なメトリクス収集**
+<!-- {% raw %} -->
 ```bash
 # リアルタイムモニタリング
 podman stats
 
 # 特定コンテナの詳細統計
-podman stats --format "table \{\{.Container\}\}\t\{\{.CPUPerc\}\}\t\{\{.MemUsage\}\}\t\{\{.NetIO\}\}\t\{\{.BlockIO\}\}"
+podman stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
 
 # JSON形式での出力（自動化用）
 podman stats --no-stream --format json > metrics.json
 ```
+<!-- {% endraw %} -->
 
 **高度なメトリクス収集スクリプト**
 ```bash
@@ -313,6 +315,7 @@ podman run -d \
 
 #### 12.7.1 パフォーマンステストフレームワーク
 
+<!-- {% raw %} -->
 ```python
 #!/usr/bin/env python3
 # performance_test_framework.py
@@ -341,7 +344,7 @@ class PerformanceTestFramework:
             # 起動完了を待つ
             while True:
                 result = subprocess.run(
-                    ['podman', 'inspect', container, '--format', '\{\{.State.Status\}\}'],
+                    ['podman', 'inspect', container, '--format', '{{.State.Status}}'],
                     capture_output=True, text=True
                 )
                 if result.stdout.strip() == 'running':
@@ -409,6 +412,7 @@ class PerformanceTestFramework:
             for metric, value in results.items():
                 print(f"  {metric}: {value}")
 ```
+<!-- {% endraw %} -->
 
 #### 12.7.2 継続的パフォーマンス改善
 

--- a/docs/chapters/chapter14/index.md
+++ b/docs/chapters/chapter14/index.md
@@ -28,6 +28,7 @@ Podmanは、これらの要件に対して以下の価値を提供します：
 #### 14.1.1 コンプライアンス対応
 
 **セキュリティポリシーの実装**
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # security-compliance-check.sh
@@ -61,17 +62,17 @@ check() {
 }
 
 # 1. ホスト設定
-check "1.1" "Rootlessモードの確認" "podman info --format '\{\{.Host.Security.Rootless\}\}'" "true"
+check "1.1" "Rootlessモードの確認" "podman info --format '{{.Host.Security.Rootless}}'" "true"
 check "1.2" "SELinuxの有効化" "getenforce" "Enforcing"
 check "1.3" "監査ログの有効化" "auditctl -l | grep -c podman" "1"
 
 # 2. Podman設定
 check "2.1" "ユーザー名前空間の有効化" "sysctl user.max_user_namespaces" "0"
-check "2.2" "seccompプロファイルの使用" "podman info --format '\{\{.Host.Security.SECCOMPEnabled\}\}'" "true"
+check "2.2" "seccompプロファイルの使用" "podman info --format '{{.Host.Security.SECCOMPEnabled}}'" "true"
 
 # 3. イメージセキュリティ
 echo -e "\n[3.x] イメージセキュリティチェック"
-for image in $(podman images --format "\{\{.Repository\}\}:\{\{.Tag\}\}" | grep -v "localhost/"); do
+for image in $(podman images --format "{{.Repository}}:{{.Tag}}" | grep -v "localhost/"); do
     echo "  Checking image: $image"
     
     # ルートユーザーチェック
@@ -89,17 +90,17 @@ done
 # 4. コンテナランタイムセキュリティ
 echo -e "\n[4.x] ランタイムセキュリティチェック"
 for container in $(podman ps -q); do
-    name=$(podman inspect $container --format '\{\{.Name\}\}')
+    name=$(podman inspect $container --format '{{.Name}}')
     echo "  Checking container: $name"
     
     # 特権モードチェック
-    privileged=$(podman inspect $container --format '\{\{.HostConfig.Privileged\}\}')
+    privileged=$(podman inspect $container --format '{{.HostConfig.Privileged}}')
     if [ "$privileged" = "true" ]; then
         failed+=("Container $name is running in privileged mode")
     fi
     
     # ケーパビリティチェック
-    caps=$(podman inspect $container --format '\{\{.EffectiveCaps\}\}')
+    caps=$(podman inspect $container --format '{{.EffectiveCaps}}')
     if [ "$caps" != "[]" ] && [ "$caps" != "null" ]; then
         warnings+=("Container $name has additional capabilities: $caps")
     fi
@@ -130,6 +131,7 @@ EOF
 
 echo "Report saved to compliance-report-*.json"
 ```
+<!-- {% endraw %} -->
 
 #### 14.1.2 監査ログの実装
 
@@ -299,6 +301,7 @@ if __name__ == "__main__":
 
 #### 14.2.1 アクティブ-スタンバイ構成
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # ha-setup.sh
@@ -426,7 +429,7 @@ rsync -avz --delete \
     ${STANDBY}:/var/lib/containers/storage/volumes/
 
 # イメージ同期
-for image in $(ssh $ACTIVE podman images --format "\{\{.Repository\}\}:\{\{.Tag\}\}"); do
+for image in $(ssh $ACTIVE podman images --format "{{.Repository}}:{{.Tag}}"); do
     ssh $ACTIVE podman save $image | ssh $STANDBY podman load
 done
 EOF
@@ -470,6 +473,7 @@ setup_data_replication
 
 echo "HA setup completed!"
 ```
+<!-- {% endraw %} -->
 
 ### 14.3 既存システムとの統合
 

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -75,6 +75,7 @@ echo "- podman unshare: namespace操作"
 
 **問題パターン1: コンテナが即座に終了する**
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # diagnose-container-exit.sh
@@ -84,7 +85,7 @@ CONTAINER=$1
 echo "Diagnosing container exit: $CONTAINER"
 
 # 1. 終了コード確認
-EXIT_CODE=$(podman inspect $CONTAINER --format '\{\{.State.ExitCode\}\}')
+EXIT_CODE=$(podman inspect $CONTAINER --format '{{.State.ExitCode}}')
 echo "Exit code: $EXIT_CODE"
 
 case $EXIT_CODE in
@@ -129,20 +130,22 @@ podman logs --tail 20 $CONTAINER
 # 3. リソース制限確認
 echo -e "\nリソース制限:"
 podman inspect $CONTAINER --format '
-Memory Limit: \{\{.HostConfig.Memory\}\}
-CPU Limit: \{\{.HostConfig.CpuQuota\}\}
+Memory Limit: {{.HostConfig.Memory}}
+CPU Limit: {{.HostConfig.CpuQuota}}
 '
 
 # 4. ヘルスチェック結果
-if podman inspect $CONTAINER --format '\{\{.Config.Healthcheck\}\}' | grep -q "map"; then
+if podman inspect $CONTAINER --format '{{.Config.Healthcheck}}' | grep -q "map"; then
     echo -e "\nヘルスチェック結果:"
-    podman inspect $CONTAINER --format '\{\{.State.Health.Status\}\}'
-    podman inspect $CONTAINER --format '\{\{range .State.Health.Log\}\}\{\{.Output\}\}\{\{end\}\}'
+    podman inspect $CONTAINER --format '{{.State.Health.Status}}'
+    podman inspect $CONTAINER --format '{{range .State.Health.Log}}{{.Output}}{{end}}'
 fi
 ```
+<!-- {% endraw %} -->
 
 **問題パターン2: Permission Denied エラー**
 
+<!-- {% raw %} -->
 ```bash
 # fix-permission-issues.sh
 
@@ -167,7 +170,7 @@ fi
 
 # 2. ユーザー名前空間確認
 echo -e "\n=== User Namespace Check ==="
-if podman info --format '\{\{.Host.Security.Rootless\}\}' | grep -q true; then
+if podman info --format '{{.Host.Security.Rootless}}' | grep -q true; then
     echo "Running in rootless mode"
     
     # UID/GIDマッピング確認
@@ -190,10 +193,12 @@ echo "マウントポイントの権限確認方法:"
 echo "ls -la /host/path"
 echo "podman exec <container> ls -la /container/path"
 ```
+<!-- {% endraw %} -->
 
 #### 15.2.2 ネットワーク関連の問題
 
 **診断スクリプト**
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # network-diagnostics.sh
@@ -205,10 +210,10 @@ echo "=== Network Diagnostics for $CONTAINER ==="
 # 1. ネットワーク設定確認
 echo "Network configuration:"
 podman inspect $CONTAINER --format '
-Network Mode: \{\{.HostConfig.NetworkMode\}\}
-IP Address: \{\{.NetworkSettings.IPAddress\}\}
-Gateway: \{\{.NetworkSettings.Gateway\}\}
-DNS: \{\{.HostConfig.Dns\}\}
+Network Mode: {{.HostConfig.NetworkMode}}
+IP Address: {{.NetworkSettings.IPAddress}}
+Gateway: {{.NetworkSettings.Gateway}}
+DNS: {{.HostConfig.Dns}}
 '
 
 # 2. ポートマッピング確認
@@ -252,6 +257,7 @@ echo -e "\nDefined networks:"
 podman network ls --format json |
     jq '.[] | {name, driver, network_interface, dns_enabled, subnets}'
 ```
+<!-- {% endraw %} -->
 
 この診断はPodman v6.0.1を基準に2026-07-21に確認しています。現行環境ではCNI directoryやpluginの有無を正常性条件にせず、Netavark backend、aardvark-dns情報、`podman network`の公開出力を確認します。rootful containerの通信がfirewalld reload後に失われた場合は、[`podman network reload`](https://docs.podman.io/en/stable/markdown/podman-network-reload.1.html)で当該containerまたは全containerのruleを復旧します。
 
@@ -277,6 +283,7 @@ sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
 #### 15.2.3 ストレージ関連の問題
 
 **ストレージ診断スクリプト**
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # storage-diagnostics.sh
@@ -290,11 +297,11 @@ podman system df
 # 2. 詳細な使用量分析
 echo -e "\nDetailed usage:"
 echo "Images:"
-podman images --format "table \{\{.Repository\}\}:\{\{.Tag\}\}\t\{\{.Size\}\}" | sort -k2 -hr | head -10
+podman images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" | sort -k2 -hr | head -10
 
 echo -e "\nVolumes:"
 for vol in $(podman volume ls -q); do
-    size=$(podman volume inspect $vol --format '\{\{.Mountpoint\}\}' | xargs du -sh 2>/dev/null | cut -f1)
+    size=$(podman volume inspect $vol --format '{{.Mountpoint}}' | xargs du -sh 2>/dev/null | cut -f1)
     echo "$vol: $size"
 done
 
@@ -307,10 +314,10 @@ echo "Unused volumes: $(podman volume ls -f dangling=true -q | wc -l)"
 # 4. ストレージドライバー情報
 echo -e "\nStorage driver info:"
 podman info --format '
-Storage Driver: \{\{.Store.GraphDriverName\}\}
-Graph Root: \{\{.Store.GraphRoot\}\}
-Run Root: \{\{.Store.RunRoot\}\}
-Volume Path: \{\{.Store.VolumePath\}\}
+Storage Driver: {{.Store.GraphDriverName}}
+Graph Root: {{.Store.GraphRoot}}
+Run Root: {{.Store.RunRoot}}
+Volume Path: {{.Store.VolumePath}}
 '
 
 # 5. クリーンアップ推奨事項
@@ -323,6 +330,7 @@ echo "podman system prune"
 echo "# 影響が大きい操作（未使用イメージ/ボリュームも削除され得るため注意）"
 echo "# podman system prune --all --volumes"
 ```
+<!-- {% endraw %} -->
 
 ### 15.3 高度なデバッグ技術
 
@@ -527,6 +535,7 @@ if __name__ == "__main__":
 
 #### 15.4.1 権限昇格の防止
 
+<!-- {% raw %} -->
 ```bash
 #!/bin/bash
 # security-hardening.sh
@@ -536,8 +545,8 @@ echo "=== Security Hardening Check ==="
 # 1. 特権コンテナの検出
 echo "Checking for privileged containers:"
 for container in $(podman ps -q); do
-    name=$(podman inspect $container --format '\{\{.Name\}\}')
-    privileged=$(podman inspect $container --format '\{\{.HostConfig.Privileged\}\}')
+    name=$(podman inspect $container --format '{{.Name}}')
+    privileged=$(podman inspect $container --format '{{.HostConfig.Privileged}}')
     
     if [ "$privileged" = "true" ]; then
         echo "[WARN] $name is running in privileged mode"
@@ -551,8 +560,8 @@ done
 # 2. 過剰なケーパビリティの検出
 echo -e "\nChecking capabilities:"
 for container in $(podman ps -q); do
-    name=$(podman inspect $container --format '\{\{.Name\}\}')
-    caps=$(podman inspect $container --format '\{\{.EffectiveCaps\}\}')
+    name=$(podman inspect $container --format '{{.Name}}')
+    caps=$(podman inspect $container --format '{{.EffectiveCaps}}')
     
     if [ "$caps" != "[]" ] && [ "$caps" != "null" ]; then
         echo "Container: $name"
@@ -571,7 +580,7 @@ done
 # 3. ユーザー権限の確認
 echo -e "\nChecking user permissions:"
 for container in $(podman ps -q); do
-    name=$(podman inspect $container --format '\{\{.Name\}\}')
+    name=$(podman inspect $container --format '{{.Name}}')
     user=$(podman exec $container whoami 2>/dev/null || echo "unknown")
     
     if [ "$user" = "root" ]; then
@@ -580,6 +589,7 @@ for container in $(podman ps -q); do
     fi
 done
 ```
+<!-- {% endraw %} -->
 
 #### 15.4.2 セキュリティポリシー違反の検出
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "check:podman-backends": "node scripts/check-podman-backend-contract.js && node scripts/check-podman-backend-contract-regression.js",
     "check:podman-machine-paths": "node scripts/check-podman-machine-path-contract.js && node scripts/check-podman-machine-path-contract-regression.js",
     "check:docker-rootless-comparison": "node scripts/check-docker-rootless-comparison.js && node scripts/check-docker-rootless-comparison-regression.js",
-    "test": "npm run check:metadata && npm run check:figure-index && npm run check:podman-backends && npm run check:podman-machine-paths && npm run check:docker-rootless-comparison && npm run build"
+    "check:literal-templates": "node scripts/check-literal-template-rendering.js && node scripts/check-literal-template-rendering-regression.js",
+    "test": "npm run check:metadata && npm run check:figure-index && npm run check:podman-backends && npm run check:podman-machine-paths && npm run check:docker-rootless-comparison && npm run check:literal-templates && npm run build"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0"

--- a/scripts/check-literal-template-rendering-regression.js
+++ b/scripts/check-literal-template-rendering-regression.js
@@ -19,6 +19,13 @@ const fixtures = [
       "{% raw %}podman inspect --format '{{.Name}}'{% endraw %}"
     ),
   ],
+  [
+    'embedded-comment-boundary',
+    validGo.replace(
+      "podman inspect --format '{{.Name}}'",
+      `${rawOpen}\npodman inspect --format '{{.Name}}'`
+    ),
+  ],
   ['orphan-opening-boundary', `${rawOpen}\nnot a fence\n`],
 ];
 

--- a/scripts/check-literal-template-rendering-regression.js
+++ b/scripts/check-literal-template-rendering-regression.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/* Regression fixtures for literal template rendering boundaries. */
+
+'use strict';
+
+const { rawOpen, rawClose, validateMarkdown } = require('./check-literal-template-rendering');
+
+const validGo = `${rawOpen}\n\`\`\`bash\npodman inspect --format '{{.Name}}'\n\`\`\`\n${rawClose}\n`;
+const validActions = `${rawOpen}\n\`\`\`yaml\nIMAGE_NAME: \${{ github.repository }}\n\`\`\`\n${rawClose}\n`;
+const fixtures = [
+  ['escaped-go-template', validGo.replace('{{.Name}}', '\\{\\{.Name\\}\\}')],
+  ['unprotected-go-template', validGo.replace(`${rawOpen}\n`, '').replace(`\n${rawClose}`, '')],
+  ['unprotected-actions-expression', validActions.replace(`${rawOpen}\n`, '').replace(`\n${rawClose}`, '')],
+  ['missing-closing-boundary', validGo.replace(`\n${rawClose}`, '')],
+  [
+    'inline-raw-tag',
+    validGo.replace(
+      "podman inspect --format '{{.Name}}'",
+      "{% raw %}podman inspect --format '{{.Name}}'{% endraw %}"
+    ),
+  ],
+  ['orphan-opening-boundary', `${rawOpen}\nnot a fence\n`],
+];
+
+for (const [label, text] of fixtures) {
+  if (validateMarkdown(text, label).length === 0) throw new Error(`negative fixture was accepted: ${label}`);
+}
+for (const [label, text] of [['valid-go', validGo], ['valid-actions', validActions], ['plain-code', '```bash\necho ok\n```\n']]) {
+  const errors = validateMarkdown(text, label);
+  if (errors.length) throw new Error(`positive fixture was rejected: ${label}: ${errors.join('; ')}`);
+}
+
+console.log(`Literal template rendering regression fixtures: OK (${fixtures.length} negative, 3 positive)`);

--- a/scripts/check-literal-template-rendering.js
+++ b/scripts/check-literal-template-rendering.js
@@ -83,8 +83,7 @@ function validateMarkdown(text, sourceLabel = 'markdown') {
         errors.push(`${sourceLabel}:${line}: literal template block is missing the closing Liquid raw boundary`);
       }
     }
-    const withoutCommentBoundaries = block.text.replaceAll(rawOpen, '').replaceAll(rawClose, '');
-    if (withoutCommentBoundaries.includes('{% raw %}') || withoutCommentBoundaries.includes('{% endraw %}')) {
+    if (block.text.includes('{% raw %}') || block.text.includes('{% endraw %}')) {
       errors.push(`${sourceLabel}:${line}: raw tag is embedded in copyable code instead of an HTML comment boundary`);
     }
   }

--- a/scripts/check-literal-template-rendering.js
+++ b/scripts/check-literal-template-rendering.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/* Ensure literal template braces remain copyable through GitHub Pages' Liquid pass. */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const docsRoot = path.join(repoRoot, 'docs');
+const rawOpen = '<!-- {% raw %} -->';
+const rawClose = '<!-- {% endraw %} -->';
+
+const requiredSourceMarkers = {
+  'docs/chapters/chapter03/index.md': ["$ podman info --format '{{.Host.NetworkBackend}}'"],
+  'docs/chapters/chapter09/index.md': ['summary: "Container {{ $labels.name }} is down"'],
+  'docs/chapters/chapter10/index.md': [
+    'IMAGE_NAME: ${{ github.repository }}',
+    'http_requests_total{{app="{self.app_name}",version="{version}",status=~"5.."}}[5m]',
+  ],
+  'docs/chapters/chapter15/index.md': ["--format '{{.State.ExitCode}}'"],
+};
+
+const requiredRenderedMarkers = {
+  'chapters/chapter03/index.html': ["$ podman info --format '{{.Host.NetworkBackend}}'"],
+  'chapters/chapter09/index.html': ['Container {{ $labels.name }} is down'],
+  'chapters/chapter10/index.html': [
+    'IMAGE_NAME: ${{ github.repository }}',
+    'http_requests_total{{app="{self.app_name}",version="{version}",status=~"5.."}}[5m]',
+  ],
+  'chapters/chapter15/index.html': ["--format '{{.State.ExitCode}}'"],
+};
+
+function markdownFiles(root) {
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...markdownFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.md')) files.push(full);
+  }
+  return files;
+}
+
+function fenceBlocks(text) {
+  const lines = text.split(/\r?\n/);
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const opening = lines[index].match(/^\s*(`{3,}|~{3,})/);
+    if (!opening) continue;
+    const fenceChar = opening[1][0];
+    const start = index;
+    index += 1;
+    while (index < lines.length && !new RegExp(`^\\s*${fenceChar}{3,}\\s*$`).test(lines[index])) index += 1;
+    if (index >= lines.length) {
+      blocks.push({ start, end: lines.length - 1, closed: false, text: lines.slice(start).join('\n'), lines });
+      break;
+    }
+    blocks.push({ start, end: index, closed: true, text: lines.slice(start, index + 1).join('\n'), lines });
+  }
+  return blocks;
+}
+
+function validateMarkdown(text, sourceLabel = 'markdown') {
+  const errors = [];
+  const lines = text.split(/\r?\n/);
+  const blocks = fenceBlocks(text);
+
+  if (/\\\{\\\{|\\\}\\\}/u.test(text)) {
+    errors.push(`${sourceLabel}: escaped double braces remain in the Markdown source`);
+  }
+
+  for (const block of blocks) {
+    const line = block.start + 1;
+    if (!block.closed) {
+      errors.push(`${sourceLabel}:${line}: unclosed code fence`);
+      continue;
+    }
+    if (block.text.includes('{{')) {
+      if (lines[block.start - 1] !== rawOpen) {
+        errors.push(`${sourceLabel}:${line}: literal template block is missing the opening Liquid raw boundary`);
+      }
+      if (lines[block.end + 1] !== rawClose) {
+        errors.push(`${sourceLabel}:${line}: literal template block is missing the closing Liquid raw boundary`);
+      }
+    }
+    const withoutCommentBoundaries = block.text.replaceAll(rawOpen, '').replaceAll(rawClose, '');
+    if (withoutCommentBoundaries.includes('{% raw %}') || withoutCommentBoundaries.includes('{% endraw %}')) {
+      errors.push(`${sourceLabel}:${line}: raw tag is embedded in copyable code instead of an HTML comment boundary`);
+    }
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index] === rawOpen && !/^\s*(`{3,}|~{3,})/.test(lines[index + 1] || '')) {
+      errors.push(`${sourceLabel}:${index + 1}: opening Liquid raw boundary is not adjacent to a code fence`);
+    }
+    if (lines[index] === rawClose && !/^\s*(`{3,}|~{3,})\s*$/.test(lines[index - 1] || '')) {
+      errors.push(`${sourceLabel}:${index + 1}: closing Liquid raw boundary is not adjacent to a code fence`);
+    }
+  }
+  const opens = lines.filter((line) => line === rawOpen).length;
+  const closes = lines.filter((line) => line === rawClose).length;
+  if (opens !== closes) errors.push(`${sourceLabel}: Liquid raw boundary count differs (${opens} open, ${closes} close)`);
+
+  return errors;
+}
+
+function validateSource() {
+  const errors = [];
+  let protectedBlocks = 0;
+  const files = markdownFiles(docsRoot);
+  for (const file of files) {
+    const relative = path.relative(repoRoot, file).split(path.sep).join('/');
+    const text = fs.readFileSync(file, 'utf8');
+    errors.push(...validateMarkdown(text, relative));
+    protectedBlocks += text.split(rawOpen).length - 1;
+  }
+  for (const [relative, markers] of Object.entries(requiredSourceMarkers)) {
+    const file = path.join(repoRoot, relative);
+    if (!fs.existsSync(file)) {
+      errors.push(`${relative}: required source file is missing`);
+      continue;
+    }
+    const text = fs.readFileSync(file, 'utf8');
+    for (const marker of markers) {
+      if (!text.includes(marker)) errors.push(`${relative}: missing literal source marker: ${marker}`);
+    }
+  }
+  return { errors, fileCount: files.length, protectedBlocks };
+}
+
+function decodeHtml(text) {
+  const named = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ' };
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, entity) => {
+      if (entity[0] === '#') {
+        const hex = entity[1].toLowerCase() === 'x';
+        const value = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
+        return Number.isFinite(value) ? String.fromCodePoint(value) : match;
+      }
+      return Object.prototype.hasOwnProperty.call(named, entity.toLowerCase()) ? named[entity.toLowerCase()] : match;
+    })
+    .replace(/\r/g, '');
+}
+
+function htmlFiles(root) {
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...htmlFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.html')) files.push(full);
+  }
+  return files;
+}
+
+function validateRenderedSite(siteRoot) {
+  const errors = [];
+  if (!fs.existsSync(siteRoot)) return { errors: [`rendered site is missing: ${siteRoot}`], htmlCount: 0 };
+  const files = htmlFiles(siteRoot);
+  for (const file of files) {
+    const relative = path.relative(siteRoot, file).split(path.sep).join('/');
+    const renderedText = decodeHtml(fs.readFileSync(file, 'utf8'));
+    if (/\\\{\\\{|\\\}\\\}/u.test(renderedText)) {
+      errors.push(`${relative}: rendered HTML still contains escaped double braces`);
+    }
+  }
+  for (const [relative, markers] of Object.entries(requiredRenderedMarkers)) {
+    const file = path.join(siteRoot, relative);
+    if (!fs.existsSync(file)) {
+      errors.push(`${relative}: required rendered page is missing`);
+      continue;
+    }
+    const renderedText = decodeHtml(fs.readFileSync(file, 'utf8'));
+    for (const marker of markers) {
+      if (!renderedText.includes(marker)) errors.push(`${relative}: missing rendered literal marker: ${marker}`);
+    }
+  }
+  return { errors, htmlCount: files.length };
+}
+
+function main() {
+  const siteFlag = process.argv.indexOf('--site');
+  const source = validateSource();
+  const errors = [...source.errors];
+  let rendered = null;
+  if (siteFlag >= 0) {
+    const value = process.argv[siteFlag + 1];
+    if (!value) errors.push('--site requires a directory');
+    else {
+      rendered = validateRenderedSite(path.resolve(value));
+      errors.push(...rendered.errors);
+    }
+  }
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  const renderedSummary = rendered ? ` + ${rendered.htmlCount} rendered HTML files` : '';
+  console.log(`Literal template rendering contract: OK (${source.protectedBlocks} protected blocks${renderedSummary})`);
+}
+
+if (require.main === module) main();
+
+module.exports = { rawOpen, rawClose, validateMarkdown, validateRenderedSite, validateSource };

--- a/scripts/check-podman-backend-contract.js
+++ b/scripts/check-podman-backend-contract.js
@@ -24,7 +24,7 @@ const contracts = {
     path: 'docs/chapters/chapter03/index.md',
     required: [
       'podman info --format json',
-      "{% raw %}$ podman info --format '{{.Host.NetworkBackend}}'{% endraw %}",
+      "$ podman info --format '{{.Host.NetworkBackend}}'",
       'podman network inspect',
       '/etc/containers/networks',
       '$graphroot/networks',


### PR DESCRIPTION
## Summary

- 11 Markdown files・29 fenced code blocksをLiquid-safeなHTML comment raw境界で保護
- 10 files / 63 linesの`\{\{...\}\}`をcopy可能なliteral braceへ復元
- Chapter 3のinline raw tagをcode block外へ移し、GitHub上でcommandにraw tagが混ざらない形式へ統一
- productionで`IMAGE_NAME: $`へ欠落していたChapter 10のGitHub Actions `${{ ... }}`も、式内容を変えず同じraw境界で保護
- sourceとJekyll生成HTMLを検査するQA contract（7 negative / 3 positive fixture、代表4 pagesのrendered marker）をCIへ統合

## Rendering contract

- GitHub Markdown: `<!-- ... -->`のraw境界は非表示で、code block内は正しいtemplateを表示
- Jekyll/Liquid: comment内の`{% raw %}` / `{% endraw %}`がliteral braceを保護
- Node build: sourceをそのままcopyし、source contractでescaped/unprotected blockを検出
- expression semantics: Go template、GitHub Actions、Alertmanager、Prometheus/Python f-string、Nginxの式内容は変更なし

## Verification

- `npm audit --audit-level=low`: 0 vulnerabilities
- `npm test`: 全contract、literal template 29 blocks、Node build成功
- Jekyll build: 31 HTML pages。escaped brace 0、Chapter 3/9/10/15のliteral marker保持
- mechanical transformation audit: 11 docsが「raw境界追加・brace unescape・旧inline raw除去」のみであることをparent treeと照合
- local Podman 4.9.3: `podman info --format '{{.Host.NetworkBackend}}'`と`podman images --format ...`成功
- Python f-string: Prometheus label selectorとNginx braceの生成結果をassert
- pinned book-formatter `69eb5c12...`: Unicode / Textlint / Links / Layout / Structure error 0
- `git diff --check`成功

## Scope

- GitHub Actions式などの意味・versionは変更しない
- Chapter 6/15のlegacy CNI是正は#220/PR #222で分離済み

Closes #221

